### PR TITLE
Edited K-Means doxy comments

### DIFF
--- a/include/algorithms/kmeans/kmeans_batch.h
+++ b/include/algorithms/kmeans/kmeans_batch.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the interface for the K-Means algorithm in the batch
+//  Implementation of the interface for K-Means algorithm in the batch
 //  processing mode
 //--
 */
@@ -46,7 +46,7 @@ namespace interface1
  */
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__BATCHCONTAINER"></a>
- * \brief Provides methods to run implementations of the K-Means algorithm.
+ * \brief Provides methods to run implementations of K-Means algorithm.
  *        This class is associated with the daal::algorithms::kmeans::Batch class
  *        and supports the method of K-Means computation in the batch processing mode
  *
@@ -58,7 +58,7 @@ class BatchContainer : public daal::algorithms::AnalysisContainerIface<batch>
 {
 public:
     /**
-     * Constructs a container for the K-Means algorithm with a specified environment
+     * Constructs a container for K-Means algorithm with a specified environment
      * in the batch processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -66,23 +66,23 @@ public:
     /** Default destructor */
     virtual ~BatchContainer();
     /**
-     * Computes the result of the K-Means algorithm in the batch processing mode
+     * Computes the result of K-Means algorithm in the batch processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
 };
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__BATCH"></a>
- * \brief Computes the results of the K-Means algorithm in the batch processing mode
+ * \brief Computes the results of K-Means algorithm in the batch processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm description and usage models</a> -->
  *
  * \tparam algorithmFPType  Data type to use in intermediate computations of K-Means, double or float
  * \tparam method           Computation method of the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Computation methods for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of the K-Means algorithm
+ *      - \ref Method   Computation methods for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of K-Means algorithm
  */
 template<typename algorithmFPType = DAAL_ALGORITHM_FP_TYPE, Method method = lloydDense>
 class DAAL_EXPORT Batch : public daal::algorithms::Analysis<batch>
@@ -103,7 +103,7 @@ public:
     }
 
     /**
-     * Constructs a K-Means algorithm by copying input objects and parameters
+     * Constructs K-Means algorithm by copying input objects and parameters
      * of another K-Means algorithm
      * \param[in] other An algorithm to be used as the source to initialize the input objects
      *                  and parameters of the algorithm
@@ -122,8 +122,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of the K-Means algorithm
-     * \return Structure that contains the results of the K-Means algorithm
+     * Returns the structure that contains the results of K-Means algorithm
+     * \return Structure that contains the results of K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -131,8 +131,8 @@ public:
     }
 
     /**
-     * Registers user-allocated  memory  to store the results of the K-Means algorithm
-     * \param[in] result  Structure to store the results of the K-Means algorithm
+     * Registers user-allocated  memory  to store the results of K-Means algorithm
+     * \param[in] result  Structure to store the results of K-Means algorithm
      */
     services::Status setResult(const ResultPtr& result)
     {

--- a/include/algorithms/kmeans/kmeans_distributed.h
+++ b/include/algorithms/kmeans/kmeans_distributed.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the interface for the K-Means algorithm in the distributed
+//  Implementation of the interface for K-Means algorithm in the distributed
 //  processing mode
 //--
 */
@@ -46,7 +46,7 @@ namespace interface1
  */
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTEDCONTAINER"></a>
- * \brief Provides methods to run implementations of the K-Means algorithm.
+ * \brief Provides methods to run implementations of K-Means algorithm.
  *        This class is associated with the daal::algorithms::kmeans::Distributed class
  *        and supports the method of K-Means computation in the distributed processing mode.
  *
@@ -58,7 +58,7 @@ class DistributedContainer;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTEDCONTAINER_STEP1LOCAL_ALGORITHMFPTYPE_METHOD_CPU"></a>
- * \brief Class containing computation methods for the K-Means algorithm in the first step of the distributed processing mode
+ * \brief Class containing computation methods for K-Means algorithm in the first step of the distributed processing mode
  */
 template<typename algorithmFPType, Method method, CpuType cpu>
 class DistributedContainer<step1Local, algorithmFPType, method, cpu> : public
@@ -66,7 +66,7 @@ class DistributedContainer<step1Local, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-     * Constructs a container for the K-Means algorithm with a specified environment
+     * Constructs a container for K-Means algorithm with a specified environment
      * in the first step of the distributed processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -74,12 +74,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-     * Computes a partial result of the K-Means algorithm in the first step of the
+     * Computes a partial result of K-Means algorithm in the first step of the
      * distributed processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-     * Computes the result of the K-Means algorithm in the first step of the
+     * Computes the result of K-Means algorithm in the first step of the
      * distributed processing mode
      */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -87,7 +87,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTEDCONTAINER_STEP2MASTER_ALGORITHMFPTYPE_METHOD_CPU"></a>
- * \brief Class containing computation methods for the K-Means algorithm in the second step of the distributed processing mode
+ * \brief Class containing computation methods for K-Means algorithm in the second step of the distributed processing mode
  */
 template<typename algorithmFPType, Method method, CpuType cpu>
 class DistributedContainer<step2Master, algorithmFPType, method, cpu> : public
@@ -95,7 +95,7 @@ class DistributedContainer<step2Master, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-     * Constructs a container for the K-Means algorithm with a specified environment
+     * Constructs a container for K-Means algorithm with a specified environment
      * in the second step of the distributed processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -103,12 +103,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-     * Computes a partial result of the K-Means algorithm in the second step of the
+     * Computes a partial result of K-Means algorithm in the second step of the
      * distributed processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-     * Computes the result of the K-Means algorithm in the second step of the
+     * Computes the result of K-Means algorithm in the second step of the
      * distributed processing mode
      */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -116,16 +116,16 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTED"></a>
- * \brief Computes the results of the K-Means algorithm in the distributed processing mode
+ * \brief Computes the results of K-Means algorithm in the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm description and usage models</a> -->
  *
  * \tparam algorithmFPType  Data type to use in intermediate computations of K-Means, double or float
  * \tparam method           Computation method of the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Computation methods for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of the K-Means algorithm
+ *      - \ref Method   Computation methods for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of K-Means algorithm
  *
  * \par References
  *      - Input class
@@ -136,16 +136,16 @@ class DAAL_EXPORT Distributed {};
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTED_STEP1LOCAL_ALGORITHMFPTYPE_METHOD"></a>
- * \brief Computes the results of the K-Means algorithm in the first step of the distributed processing mode
+ * \brief Computes the results of K-Means algorithm in the first step of the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm description and usage models</a> -->
  *
  * \tparam algorithmFPType  Data type to use in intermediate computations of K-Means, double or float
  * \tparam method           Computation method of the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Computation methods for the K-Means algorithm
+ *      - \ref Method   Computation methods for K-Means algorithm
  *      - \ref InputId  Identifiers of input objects for the  K-Means algorithm
- *      - \ref ResultId Identifiers of results of the K-Means algorithm
+ *      - \ref ResultId Identifiers of results of K-Means algorithm
  */
 template<typename algorithmFPType, Method method>
 class DAAL_EXPORT Distributed<step1Local, algorithmFPType, method> : public daal::algorithms::Analysis<distributed>
@@ -157,7 +157,7 @@ public:
     typedef algorithms::kmeans::PartialResult PartialResultType;
 
     /**
-     * Constructs a K-Means algorithm
+     * Constructs K-Means algorithm
      *  \param[in] nClusters  Number of clusters
      *  \param[in] assignFlag Flag to calculate partial assignment
      */
@@ -168,7 +168,7 @@ public:
     }
 
     /**
-     * Constructs a K-Means algorithm by copying input objects and parameters
+     * Constructs K-Means algorithm by copying input objects and parameters
      * of another K-Means algorithm
      * \param[in] other An algorithm to be used as the source to initialize the input objects
      *                  and parameters of the algorithm
@@ -187,8 +187,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of the K-Means algorithm
-     * \return Structure that contains the results of the K-Means algorithm
+     * Returns the structure that contains the results of K-Means algorithm
+     * \return Structure that contains the results of K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -196,8 +196,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store the results of the K-Means algorithm
-     * \param[in] result  Structure to store the results of the K-Means algorithm
+     * Registers user-allocated memory to store the results of K-Means algorithm
+     * \param[in] result  Structure to store the results of K-Means algorithm
      */
     services::Status setResult(const ResultPtr& result)
     {
@@ -290,16 +290,16 @@ private:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTED_STEP2MASTER_ALGORITHMFPTYPE_METHOD"></a>
- * \brief Computes the results of the K-Means algorithm in the second step of the distributed processing mode
+ * \brief Computes the results of K-Means algorithm in the second step of the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm description and usage models</a> -->
  *
  * \tparam algorithmFPType  Data type to use in intermediate computations of K-Means, double or float
  * \tparam method           Computation method of the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Computation methods for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of the K-Means algorithm
+ *      - \ref Method   Computation methods for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of K-Means algorithm
  *
  * \par References
  *      - Input  class
@@ -325,7 +325,7 @@ public:
     }
 
     /**
-     * Constructs a K-Means algorithm by copying input objects and parameters
+     * Constructs K-Means algorithm by copying input objects and parameters
      * of another K-Means algorithm
      * \param[in] other An algorithm to be used as the source to initialize the input objects
      *                  and parameters of the algorithm
@@ -343,8 +343,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of the K-Means algorithm
-     * \return Structure that contains the results of the K-Means algorithm
+     * Returns the structure that contains the results of K-Means algorithm
+     * \return Structure that contains the results of K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -352,8 +352,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store the results of the K-Means algorithm
-     * \param[in] result  Structure to store the results of the K-Means algorithm
+     * Registers user-allocated memory to store the results of K-Means algorithm
+     * \param[in] result  Structure to store the results of K-Means algorithm
      */
     services::Status setResult(const ResultPtr& result)
     {

--- a/include/algorithms/kmeans/kmeans_init_batch.h
+++ b/include/algorithms/kmeans/kmeans_init_batch.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the interface for initializing the K-Means algorithm
+//  Implementation of the interface for initializing K-Means algorithm
 //  in the batch processing mode
 //--
 */
@@ -48,11 +48,11 @@ namespace interface2
  */
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__BATCHCONTAINER"></a>
- * \brief Provides methods to run implementations of initialization of the K-Means algorithm.
+ * \brief Provides methods to run implementations of initialization of K-Means algorithm.
  *        This class is associated with the daal::algorithms::kmeans::init::Batch class
- *        and supports the method of computing initial clusters for the K-Means algorithm in the batch processing mode.
+ *        and supports the method of computing initial clusters for K-Means algorithm in the batch processing mode.
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method           Method of computing initial clusters for the algorithm, \ref daal::algorithms::kmeans::init::Method
  */
 template<typename algorithmFPType, Method method, CpuType cpu>
@@ -60,7 +60,7 @@ class BatchContainer : public daal::algorithms::AnalysisContainerIface<batch>
 {
 public:
     /**
-     * Constructs a container for initializing the K-Means algorithm with a specified environment
+     * Constructs a container for initializing K-Means algorithm with a specified environment
      * in the batch processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -68,7 +68,7 @@ public:
     /** Default destructor */
     virtual ~BatchContainer();
     /**
-     * Computes initial values for the K-Means algorithm in the batch processing mode
+     * Computes initial values for K-Means algorithm in the batch processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
 };
@@ -76,7 +76,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__BATCHBASE"></a>
- *  \brief Base class representing an K-Means algorithm initialization in the batch processing mode
+ *  \brief Base class representing K-Means algorithm initialization in the batch processing mode
  */
 class DAAL_EXPORT BatchBase : public daal::algorithms::Analysis<batch>
 {
@@ -99,16 +99,16 @@ protected:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__BATCH"></a>
- * \brief Computes initial clusters for the K-Means algorithm in the batch processing mode
+ * \brief Computes initial clusters for K-Means algorithm in the batch processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method           Method of computing initial clusters for the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+ *      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of computing initial clusters for K-Means algorithm
  */
 template<typename algorithmFPType = DAAL_ALGORITHM_FP_TYPE, Method method = defaultDense>
 class DAAL_EXPORT Batch : public BatchBase
@@ -121,7 +121,7 @@ public:
     Batch(size_t nClusters);
 
     /**
-     * Constructs an algorithm that computes initial clusters for the K-Means algorithm
+     * Constructs an algorithm that computes initial clusters for K-Means algorithm
      * by copying input objects and parameters of another algorithm
      * \param[in] other An algorithm to be used as the source to initialize the input objects
      *                  and parameters of the algorithm
@@ -142,8 +142,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of computing initial clusters for the K-Means algorithm
-     * \return Structure that contains the results of computing initial clusters for the K-Means algorithm
+     * Returns the structure that contains the results of computing initial clusters for K-Means algorithm
+     * \return Structure that contains the results of computing initial clusters for K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -151,8 +151,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store the results of computing initial clusters for the K-Means algorithm
-     * \param[in] result  Structure to store the results of computing initial clusters for the K-Means algorithm
+     * Registers user-allocated memory to store the results of computing initial clusters for K-Means algorithm
+     * \param[in] result  Structure to store the results of computing initial clusters for K-Means algorithm
      */
     services::Status setResult(const ResultPtr& result)
     {
@@ -163,7 +163,7 @@ public:
     }
 
     /**
-     * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+     * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
      * with a copy of input objects and parameters of this algorithm
      * \return Pointer to the newly allocated algorithm
      */

--- a/include/algorithms/kmeans/kmeans_init_distributed.h
+++ b/include/algorithms/kmeans/kmeans_init_distributed.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the interface for initializing the K-Means algorithm
+//  Implementation of the interface for initializing K-Means algorithm
 //  in the distributed processing mode
 //--
 */
@@ -48,11 +48,11 @@ namespace interface2
  */
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER"></a>
- * \brief Provides methods to run implementations of initialization of the K-Means algorithm.
+ * \brief Provides methods to run implementations of initialization of K-Means algorithm.
  *        This class is associated with the daal::algorithms::kmeans::init::Distributed class
- *        and supports the method of computing initial clusters for the K-Means algorithm in the distributed processing mode.
+ *        and supports the method of computing initial clusters for K-Means algorithm in the distributed processing mode.
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method           Method of computing initial clusters for the algorithm, \ref daal::algorithms::kmeans::init::Method
  */
 template<ComputeStep step, typename algorithmFPType, Method method, CpuType cpu>
@@ -60,7 +60,7 @@ class DistributedContainer;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP1LOCAL_ALGORITHMFPTYPE_METHOD_CPU"></a>
- * \brief Class containing methods for computing initial clusters for the K-Means algorithm in the first step of the distributed processing mode
+ * \brief Class containing methods for computing initial clusters for K-Means algorithm in the first step of the distributed processing mode
  */
 template<typename algorithmFPType, Method method, CpuType cpu>
 class DistributedContainer<step1Local, algorithmFPType, method, cpu> : public
@@ -68,7 +68,7 @@ class DistributedContainer<step1Local, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-     * Constructs a container for initializing the K-Means algorithm with a specified environment
+     * Constructs a container for initializing K-Means algorithm with a specified environment
      * in the first step of the distributed processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -76,12 +76,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-     * Computes a partial result of the K-Means initialization algorithm in the first step of the
+     * Computes a partial result of K-Means initialization algorithm in the first step of the
      * distributed processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-     * Computes the result of the K-Means initialization algorithm in the first step of the
+     * Computes the result of K-Means initialization algorithm in the first step of the
      * distributed processing mode
      */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -89,7 +89,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP2MASTER_ALGORITHMFPTYPE_METHOD_CPU"></a>
- * \brief Class containing methods for computing initial clusters for the K-Means algorithm in the 2nd step of the distributed processing mode
+ * \brief Class containing methods for computing initial clusters for K-Means algorithm in the 2nd step of the distributed processing mode
  */
 template<typename algorithmFPType, Method method, CpuType cpu>
 class DistributedContainer<step2Master, algorithmFPType, method, cpu> : public
@@ -97,7 +97,7 @@ class DistributedContainer<step2Master, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-     * Constructs a container for initializing the K-Means algorithm with a specified environment
+     * Constructs a container for initializing K-Means algorithm with a specified environment
      * in the 2nd step of the distributed processing mode
      * \param[in] daalEnv   Environment object
      */
@@ -105,12 +105,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-     * Computes a partial result of the K-Means initialization algorithm in the 2nd step of the
+     * Computes a partial result of K-Means initialization algorithm in the 2nd step of the
      * distributed processing mode
      */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-     * Computes the result of the K-Means initialization algorithm in the 2nd step of the
+     * Computes the result of K-Means initialization algorithm in the 2nd step of the
      * distributed processing mode
      */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -118,7 +118,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP2LOCAL_ALGORITHMFPTYPE_METHOD_CPU"></a>
-* \brief Class containing methods for computing initial clusters for the K-Means algorithm in the 2nd step of the distributed processing mode
+* \brief Class containing methods for computing initial clusters for K-Means algorithm in the 2nd step of the distributed processing mode
 *        performed on a local node
 */
 template<typename algorithmFPType, Method method, CpuType cpu>
@@ -127,7 +127,7 @@ class DistributedContainer<step2Local, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-    * Constructs a container for initializing the K-Means algorithm with a specified environment
+    * Constructs a container for initializing K-Means algorithm with a specified environment
     * in the 2nd step of the distributed processing mode
     * \param[in] daalEnv   Environment object
     */
@@ -135,12 +135,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-    * Computes a partial result of the K-Means initialization algorithm in the 2nd step of the
+    * Computes a partial result of K-Means initialization algorithm in the 2nd step of the
     * distributed processing mode
     */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-    * Computes the result of the K-Means initialization algorithm in the 2nd step of the
+    * Computes the result of K-Means initialization algorithm in the 2nd step of the
     * distributed processing mode
     */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -148,7 +148,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP3MASTER_ALGORITHMFPTYPE_METHOD_CPU"></a>
-* \brief Class containing methods for computing initial clusters for the K-Means algorithm in the 3rd step of the distributed processing mode
+* \brief Class containing methods for computing initial clusters for K-Means algorithm in the 3rd step of the distributed processing mode
 *        performed on the master mode
 */
 template<typename algorithmFPType, Method method, CpuType cpu>
@@ -157,7 +157,7 @@ class DistributedContainer<step3Master, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-    * Constructs a container for initializing the K-Means algorithm with a specified environment
+    * Constructs a container for initializing K-Means algorithm with a specified environment
     * in the 3rd step of the distributed processing mode
     * \param[in] daalEnv   Environment object
     */
@@ -165,12 +165,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-    * Computes a partial result of the K-Means initialization algorithm in the 3rd step of the
+    * Computes a partial result of K-Means initialization algorithm in the 3rd step of the
     * distributed processing mode
     */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-    * Computes the result of the K-Means initialization algorithm in the 3rd step of the
+    * Computes the result of K-Means initialization algorithm in the 3rd step of the
     * distributed processing mode
     */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -178,7 +178,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP4LOCAL_ALGORITHMFPTYPE_METHOD_CPU"></a>
-* \brief Class containing methods for computing initial clusters for the K-Means algorithm in the 4th step of the distributed processing mode
+* \brief Class containing methods for computing initial clusters for K-Means algorithm in the 4th step of the distributed processing mode
 *        performed on a local node
 */
 template<typename algorithmFPType, Method method, CpuType cpu>
@@ -187,7 +187,7 @@ class DistributedContainer<step4Local, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-    * Constructs a container for initializing the K-Means algorithm with a specified environment
+    * Constructs a container for initializing K-Means algorithm with a specified environment
     * in the 4th step of the distributed processing mode
     * \param[in] daalEnv   Environment object
     */
@@ -195,12 +195,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-    * Computes a partial result of the K-Means initialization algorithm in the 4th step of the
+    * Computes a partial result of K-Means initialization algorithm in the 4th step of the
     * distributed processing mode
     */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-    * Computes the result of the K-Means initialization algorithm in the 4th step of the
+    * Computes the result of K-Means initialization algorithm in the 4th step of the
     * distributed processing mode
     */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -208,7 +208,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDCONTAINER_STEP5MASTER_ALGORITHMFPTYPE_METHOD_CPU"></a>
-* \brief Class containing methods for computing initial clusters for the K-Means algorithm in the 5th step of the distributed processing mode
+* \brief Class containing methods for computing initial clusters for K-Means algorithm in the 5th step of the distributed processing mode
 *        performed on the master node
 */
 template<typename algorithmFPType, Method method, CpuType cpu>
@@ -217,7 +217,7 @@ class DistributedContainer<step5Master, algorithmFPType, method, cpu> : public
 {
 public:
     /**
-    * Constructs a container for initializing the K-Means algorithm with a specified environment
+    * Constructs a container for initializing K-Means algorithm with a specified environment
     * in the 5th step of the distributed processing mode
     * \param[in] daalEnv   Environment object
     */
@@ -225,12 +225,12 @@ public:
     /** Default destructor */
     virtual ~DistributedContainer();
     /**
-    * Computes a partial result of the K-Means initialization algorithm in the 5th step of the
+    * Computes a partial result of K-Means initialization algorithm in the 5th step of the
     * distributed processing mode
     */
     virtual services::Status compute() DAAL_C11_OVERRIDE;
     /**
-    * Computes the result of the K-Means initialization algorithm in the 5th step of the
+    * Computes the result of K-Means initialization algorithm in the 5th step of the
     * distributed processing mode
     */
     virtual services::Status finalizeCompute() DAAL_C11_OVERRIDE;
@@ -238,7 +238,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED"></a>
- *  \brief Base class representing an K-Means algorithm initialization in the distributed processing mode
+ *  \brief Base class representing K-Means algorithm initialization in the distributed processing mode
  */
 class DAAL_EXPORT DistributedBase : public daal::algorithms::Analysis<distributed>
 {
@@ -258,16 +258,16 @@ protected:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED"></a>
- * \brief Computes initial clusters for the K-Means algorithm in the distributed processing mode
+ * \brief Computes initial clusters for K-Means algorithm in the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method           Method of computing initial clusters for the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+ *      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of computing initial clusters for K-Means algorithm
  *
  * \par References
  *      - Input  class
@@ -278,16 +278,16 @@ class DAAL_EXPORT Distributed;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP1LOCAL_ALGORITHMFPTYPE_METHOD"></a>
- * \brief Computes initial clusters for the K-Means algorithm in the first step of the distributed processing mode
+ * \brief Computes initial clusters for K-Means algorithm in the first step of the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method            Method of computing initial clusters for the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+ *      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of computing initial clusters for K-Means algorithm
  *
  * \par References
  *      - Input  class
@@ -322,8 +322,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of computing initial clusters for the K-Means algorithm
-     * \return Structure that contains the results of computing initial clusters for the K-Means algorithm
+     * Returns the structure that contains the results of computing initial clusters for K-Means algorithm
+     * \return Structure that contains the results of computing initial clusters for K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -331,8 +331,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store the results of computing initial clusters for the K-Means algorithm
-     * \param[in] result  Structure to store the results of computing initial clusters for the K-Means algorithm
+     * Registers user-allocated memory to store the results of computing initial clusters for K-Means algorithm
+     * \param[in] result  Structure to store the results of computing initial clusters for K-Means algorithm
      */
     services::Status setResult(const ResultPtr& result)
     {
@@ -352,8 +352,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-     * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+     * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+     * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
      */
     services::Status setPartialResult(const PartialResultPtr& partialRes)
     {
@@ -372,7 +372,7 @@ public:
     }
 
     /**
-     * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+     * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
      * with a copy of input objects and parameters of this algorithm
      * \return Pointer to the newly allocated algorithm
      */
@@ -425,16 +425,16 @@ private:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP2MASTER_ALGORITHMFPTYPE_METHOD"></a>
- * \brief Computes initial clusters for the K-Means algorithm in the 2nd step of the distributed processing mode
+ * \brief Computes initial clusters for K-Means algorithm in the 2nd step of the distributed processing mode
  * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
  *
- * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+ * \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
  * \tparam method           Method of computing initial clusters for the algorithm, \ref Method
  *
  * \par Enumerations
- *      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
- *      - \ref InputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
- *      - \ref ResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+ *      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+ *      - \ref InputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
+ *      - \ref ResultId Identifiers of results of computing initial clusters for K-Means algorithm
  *
  * \par References
  *      - Input  class
@@ -462,8 +462,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE { return(int) method; }
 
     /**
-     * Returns the structure that contains the results of computing initial clusters for the K-Means algorithm
-     * \return Structure that contains the results of computing initial clusters for the K-Means algorithm
+     * Returns the structure that contains the results of computing initial clusters for K-Means algorithm
+     * \return Structure that contains the results of computing initial clusters for K-Means algorithm
      */
     ResultPtr getResult()
     {
@@ -471,8 +471,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store the results of computing initial clusters for the K-Means algorithm
-     * \param[in] result  Structure to store the results of computing initial clusters for the K-Means algorithm */
+     * Registers user-allocated memory to store the results of computing initial clusters for K-Means algorithm
+     * \param[in] result  Structure to store the results of computing initial clusters for K-Means algorithm */
     services::Status setResult(const ResultPtr& result)
     {
         DAAL_CHECK(result, services::ErrorNullResult)
@@ -491,8 +491,8 @@ public:
     }
 
     /**
-     * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-     * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+     * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+     * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
      */
     services::Status setPartialResult(const PartialResultPtr& partialRes)
     {
@@ -530,7 +530,7 @@ public:
     }
 
     /**
-     * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+     * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
      * with a copy of input objects and parameters of this algorithm
      * \return Pointer to the newly allocated algorithm
      */
@@ -590,7 +590,7 @@ private:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDPLUSPLUS"></a>
- *  \brief Base class representing an K-Means algorithm initialization in the distributed processing mode
+ *  \brief Base class representing K-Means algorithm initialization in the distributed processing mode
  */
 class DAAL_EXPORT DistributedStep2LocalPlusPlusBase : public daal::algorithms::Analysis<distributed>
 {
@@ -610,19 +610,19 @@ protected:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP2LOCAL_ALGORITHMFPTYPE_METHOD"></a>
-* \brief Computes initial clusters for the K-Means algorithm in the 2nd step of the distributed processing mode.
+* \brief Computes initial clusters for K-Means algorithm in the 2nd step of the distributed processing mode.
 *        Used with plusPlus and parallelPlus methods only on a local node.
 * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
 *
-* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
 * \tparam method            Method of computing initial clusters for the algorithm, \ref Method
 *
 * \par Enumerations
-*      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
+*      - \ref Method   Methods of computing initial clusters for K-Means algorithm
 *      - \ref DistributedStep2LocalPlusPlusInputId
-*      - \ref DistributedLocalPlusPlusInputDataId Identifiers of input objects for computing initial clusters for the K-Means algorithm
+*      - \ref DistributedLocalPlusPlusInputDataId Identifiers of input objects for computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
-*      - \ref DistributedStep2LocalPlusPlusPartialResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+*      - \ref DistributedStep2LocalPlusPlusPartialResultId Identifiers of results of computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
 *
 * \par References
@@ -666,8 +666,8 @@ public:
     }
 
     /**
-    * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-    * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+    * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+    * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
     */
     services::Status setPartialResult(const DistributedStep2LocalPlusPlusPartialResultPtr& partialRes)
     {
@@ -686,7 +686,7 @@ public:
     }
 
     /**
-    * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+    * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
     * with a copy of input objects and parameters of this algorithm
     * \return Pointer to the newly allocated algorithm
     */
@@ -736,18 +736,18 @@ private:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP3MASTER_ALGORITHMFPTYPE_METHOD"></a>
-* \brief Computes initial clusters for the K-Means algorithm in the 3rd step of the distributed processing mode.
+* \brief Computes initial clusters for K-Means algorithm in the 3rd step of the distributed processing mode.
 *        Used with plusPlus and parallelPlus methods only on the master node.
 * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
 *
-* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
 * \tparam method            Method of computing initial clusters for the algorithm, \ref Method
 *
 * \par Enumerations
-*      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
-*      - \ref DistributedStep3MasterPlusPlusInputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
+*      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+*      - \ref DistributedStep3MasterPlusPlusInputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
-*      - \ref DistributedStep3MasterPlusPlusPartialResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+*      - \ref DistributedStep3MasterPlusPlusPartialResultId Identifiers of results of computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
 *
 * \par References
@@ -789,8 +789,8 @@ public:
     }
 
     /**
-    * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-    * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+    * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+    * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
     */
     services::Status setPartialResult(const DistributedStep3MasterPlusPlusPartialResultPtr& partialRes)
     {
@@ -809,7 +809,7 @@ public:
     }
 
     /**
-    * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+    * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
     * with a copy of input objects and parameters of this algorithm
     * \return Pointer to the newly allocated algorithm
     */
@@ -859,18 +859,18 @@ private:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP4LOCAL_ALGORITHMFPTYPE_METHOD"></a>
-* \brief Computes initial clusters for the K-Means algorithm in the 4th step of the distributed processing mode.
+* \brief Computes initial clusters for K-Means algorithm in the 4th step of the distributed processing mode.
 *        Used with plusPlus and parallelPlus methods only on a local node.
 * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
 *
-* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
 * \tparam method            Method of computing initial clusters for the algorithm, \ref Method
 *
 * \par Enumerations
-*      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
-*      - \ref DistributedStep4LocalPlusPlusInputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
+*      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+*      - \ref DistributedStep4LocalPlusPlusInputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
-*      - \ref DistributedStep4LocalPlusPlusPartialResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+*      - \ref DistributedStep4LocalPlusPlusPartialResultId Identifiers of results of computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
 *
 * \par References
@@ -912,8 +912,8 @@ public:
     }
 
     /**
-    * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-    * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+    * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+    * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
     */
     services::Status setPartialResult(const DistributedStep4LocalPlusPlusPartialResultPtr& partialRes)
     {
@@ -932,7 +932,7 @@ public:
     }
 
     /**
-    * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+    * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
     * with a copy of input objects and parameters of this algorithm
     * \return Pointer to the newly allocated algorithm
     */
@@ -981,18 +981,18 @@ private:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTED_STEP5MASTER_ALGORITHMFPTYPE_METHOD"></a>
-* \brief Computes initial clusters for the K-Means algorithm in the 5th step of the distributed processing mode.
+* \brief Computes initial clusters for K-Means algorithm in the 5th step of the distributed processing mode.
 *        Used with parallelPlus method only.
 * <!-- \n<a href="DAAL-REF-KMEANS-ALGORITHM">K-Means algorithm initialization description and usage models</a> -->
 *
-* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for the K-Means algorithm, double or float
+* \tparam algorithmFPType  Data type to use in intermediate computations of initial clusters for K-Means algorithm, double or float
 * \tparam method            Method of computing initial clusters for the algorithm, \ref Method
 *
 * \par Enumerations
-*      - \ref Method   Methods of computing initial clusters for the K-Means algorithm
-*      - \ref DistributedStep5MasterPlusPlusInputId  Identifiers of input objects for computing initial clusters for the K-Means algorithm
+*      - \ref Method   Methods of computing initial clusters for K-Means algorithm
+*      - \ref DistributedStep5MasterPlusPlusInputId  Identifiers of input objects for computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
-*      - \ref DistributedStep5MasterPlusPlusPartialResultId Identifiers of results of computing initial clusters for the K-Means algorithm
+*      - \ref DistributedStep5MasterPlusPlusPartialResultId Identifiers of results of computing initial clusters for K-Means algorithm
 *             used with plusPlus and parallelPlus methods only.
 *
 * \par References
@@ -1027,8 +1027,8 @@ public:
     virtual int getMethod() const DAAL_C11_OVERRIDE{ return(int)method; }
 
     /**
-    * Returns the structure that contains the results of computing initial clusters for the K-Means algorithm
-    * \return Structure that contains the results of computing initial clusters for the K-Means algorithm
+    * Returns the structure that contains the results of computing initial clusters for K-Means algorithm
+    * \return Structure that contains the results of computing initial clusters for K-Means algorithm
     */
     ResultPtr getResult()
     {
@@ -1036,8 +1036,8 @@ public:
     }
 
     /**
-    * Registers user-allocated memory to store the results of computing initial clusters for the K-Means algorithm
-    * \param[in] result  Structure to store the results of computing initial clusters for the K-Means algorithm
+    * Registers user-allocated memory to store the results of computing initial clusters for K-Means algorithm
+    * \param[in] result  Structure to store the results of computing initial clusters for K-Means algorithm
     */
     services::Status setResult(const ResultPtr& result)
     {
@@ -1057,8 +1057,8 @@ public:
     }
 
     /**
-    * Registers user-allocated memory to store partial results of computing initial clusters for the K-Means algorithm
-    * \param[in] partialRes  Structure to store partial results of computing initial clusters for the K-Means algorithm
+    * Registers user-allocated memory to store partial results of computing initial clusters for K-Means algorithm
+    * \param[in] partialRes  Structure to store partial results of computing initial clusters for K-Means algorithm
     */
     services::Status setPartialResult(const DistributedStep5MasterPlusPlusPartialResultPtr& partialRes)
     {
@@ -1077,7 +1077,7 @@ public:
     }
 
     /**
-    * Returns a pointer to the newly allocated algorithm that computes initial clusters for the K-Means algorithm
+    * Returns a pointer to the newly allocated algorithm that computes initial clusters for K-Means algorithm
     * with a copy of input objects and parameters of this algorithm
     * \return Pointer to the newly allocated algorithm
     */

--- a/include/algorithms/kmeans/kmeans_init_types.h
+++ b/include/algorithms/kmeans/kmeans_init_types.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the interface for initializing the K-Means algorithm interface.
+//  Implementation of the interface for initializing K-Means algorithm interface.
 //--
 */
 
@@ -46,12 +46,12 @@ namespace kmeans
  * @ingroup kmeans
  * @{
  */
-/** \brief Contains classes for computing initial centroids for the K-Means algorithm */
+/** \brief Contains classes for computing initial centroids for K-Means algorithm */
 namespace init
 {
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__METHOD"></a>
- * Available methods for computing initial centroids for the K-Means algorithm
+ * Available methods for computing initial centroids for K-Means algorithm
  */
 enum Method
 {
@@ -78,7 +78,7 @@ enum Method
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__INPUTID"></a>
- * \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+ * \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
  */
 enum InputId
 {
@@ -88,7 +88,7 @@ enum InputId
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2MASTERINPUTID"></a>
- * \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm in the distributed processing mode
+ * \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm in the distributed processing mode
  */
 enum DistributedStep2MasterInputId
 {
@@ -98,7 +98,7 @@ enum DistributedStep2MasterInputId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDLOCALPLUSPLUSINPUTDATAID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with plusPlus and parallelPlus methods only on a local node.
 */
 enum DistributedLocalPlusPlusInputDataId
@@ -109,7 +109,7 @@ enum DistributedLocalPlusPlusInputDataId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSINPUTID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with plusPlus and parallelPlus methods only on the 2nd step on a local node.
 */
 enum DistributedStep2LocalPlusPlusInputId
@@ -120,7 +120,7 @@ enum DistributedStep2LocalPlusPlusInputId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP3MASTERPLUSPLUSINPUTID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with plusPlus and parallelPlus methods only on the 3rd step on a master node.
 */
 enum DistributedStep3MasterPlusPlusInputId
@@ -131,7 +131,7 @@ enum DistributedStep3MasterPlusPlusInputId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP4LOCALPLUSPLUSINPUTID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with plusPlus and parallelPlus methods only on a local node.
 */
 enum DistributedStep4LocalPlusPlusInputId
@@ -142,7 +142,7 @@ enum DistributedStep4LocalPlusPlusInputId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP5MASTERPLUSPLUSINPUTID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with parallelPlus method only on a master node.
 */
 enum DistributedStep5MasterPlusPlusInputId
@@ -154,7 +154,7 @@ enum DistributedStep5MasterPlusPlusInputId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP5MASTERPLUSPLUSINPUTDATAID"></a>
-* \brief Available identifiers of input objects for computing initial centroids for the K-Means algorithm
+* \brief Available identifiers of input objects for computing initial centroids for K-Means algorithm
 *        used with parallelPlus methods only on the 5th step on a master node.
 */
 enum DistributedStep5MasterPlusPlusInputDataId
@@ -165,7 +165,7 @@ enum DistributedStep5MasterPlusPlusInputDataId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__PARTIALRESULTID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 */
 enum PartialResultId
 {
@@ -177,7 +177,7 @@ enum PartialResultId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSPARTIALRESULTID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with plusPlus and parallelPlus methods only on the 2nd step on a local node.
 */
 enum DistributedStep2LocalPlusPlusPartialResultId
@@ -189,7 +189,7 @@ enum DistributedStep2LocalPlusPlusPartialResultId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSPARTIALRESULTDATAID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with plusPlus and parallelPlus methods only on the 2nd step on a local node.
 */
 enum DistributedStep2LocalPlusPlusPartialResultDataId
@@ -200,7 +200,7 @@ enum DistributedStep2LocalPlusPlusPartialResultDataId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP3MASTERPLUSPLUSPARTIALRESULTID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with plusPlus and parallelPlus methods only on the 3rd step on a master node.
 */
 enum DistributedStep3MasterPlusPlusPartialResultId
@@ -211,7 +211,7 @@ enum DistributedStep3MasterPlusPlusPartialResultId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP3MASTERPLUSPLUSPARTIALRESULTDATAID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with parallelPlus method only on the 3rd step on a master node.
 */
 enum DistributedStep3MasterPlusPlusPartialResultDataId
@@ -223,7 +223,7 @@ enum DistributedStep3MasterPlusPlusPartialResultDataId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP4LOCALPLUSPLUSPARTIALRESULTID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with plusPlus and parallelPlus methods only on the 4th step on a local node.
 */
 enum DistributedStep4LocalPlusPlusPartialResultId
@@ -234,7 +234,7 @@ enum DistributedStep4LocalPlusPlusPartialResultId
 
 /**
 * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP5MASTERPLUSPLUSPARTIALRESULTID"></a>
-* \brief Available identifiers of partial results of computing initial centroids for the K-Means algorithm in the distributed processing mode
+* \brief Available identifiers of partial results of computing initial centroids for K-Means algorithm in the distributed processing mode
 *        used with parallelPlus method only on the 5th step on a master node.
 */
 enum DistributedStep5MasterPlusPlusPartialResultId
@@ -246,7 +246,7 @@ enum DistributedStep5MasterPlusPlusPartialResultId
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INIT__RESULTID"></a>
- * \brief Available identifiers of the results of computing initial centroids for the K-Means algorithm
+ * \brief Available identifiers of the results of computing initial centroids for K-Means algorithm
  */
 enum ResultId
 {
@@ -262,7 +262,7 @@ namespace interface1
 {
 /**
  * <a name="DAAL-STRUCT-ALGORITHMS__KMEANS__INIT__PARAMETER"></a>
- * \brief Base classes parameters for computing initial centroids for the K-Means algorithm
+ * \brief Base classes parameters for computing initial centroids for K-Means algorithm
  *
  * \snippet kmeans/kmeans_init_types.h Parameter source code
  */
@@ -278,9 +278,9 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
     Parameter(size_t _nClusters, size_t _offset = 0, size_t _seed = 777777);
 
     /**
-     * Constructs parameters of the algorithm that computes initial centroids for the K-Means algorithm
+     * Constructs parameters of the algorithm that computes initial centroids for K-Means algorithm
      * by copying another parameters object
-     * \param[in] other    Parameters of the K-Means algorithm
+     * \param[in] other    Parameters of K-Means algorithm
      */
     Parameter(const Parameter &other);
 
@@ -290,10 +290,8 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
     size_t seed;               /*!< Seed for generating random numbers for the initialization \DAAL_DEPRECATED_USE{ engine } */
 
     double oversamplingFactor; /*!< Kmeans|| only. A fraction of nClusters being chosen in each of nRounds of kmeans||.\
-                                                   L = nClusters* oversamplingFactor points are sampled in a round.
-                                                   See section (3.3) of [2] */
-    size_t nRounds;            /*!< Kmeans|| only. Number of rounds for k-means||. (oversamplingFactor*nRounds) > 1 is a requirement.
-                                                   See section (3.3) of [2] */
+                                                   L = nClusters* oversamplingFactor points are sampled in a round. */
+    size_t nRounds;            /*!< Kmeans|| only. Number of rounds for k-means||. (oversamplingFactor*nRounds) > 1 is a requirement.*/
 
     engines::EnginePtr engine; /*!< Engine to be used for generating random numbers for the initialization */
 
@@ -303,7 +301,7 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__INPUTIFACE"></a>
- * \brief Interface for the K-Means initialization batch and distributed Input classes
+ * \brief Interface for K-Means initialization batch and distributed Input classes
  */
 class DAAL_EXPORT InputIface : public daal::algorithms::Input
 {
@@ -315,7 +313,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__INPUT"></a>
- * \brief %Input objects for computing initial centroids for the K-Means algorithm
+ * \brief %Input objects for computing initial centroids for K-Means algorithm
  */
 class DAAL_EXPORT Input : public InputIface
 {
@@ -324,14 +322,14 @@ public:
     virtual ~Input() {}
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(InputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
@@ -344,7 +342,7 @@ public:
     size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE;
 
     /**
-    * Checks an input object for computing initial centroids for the K-Means algorithm
+    * Checks an input object for computing initial centroids for K-Means algorithm
     * \param[in] par     %Input object
     * \param[in] method  Method of the algorithm
     */
@@ -356,7 +354,7 @@ protected:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__PARTIALRESULT"></a>
- * \brief Partial results obtained with the compute() method of the K-Means algorithm in the batch processing mode
+ * \brief Partial results obtained with the compute() method of K-Means algorithm in the batch processing mode
  */
 class DAAL_EXPORT PartialResult : public daal::algorithms::PartialResult
 {
@@ -367,7 +365,7 @@ public:
     virtual ~PartialResult() {};
 
     /**
-     * Allocates memory to store partial results of computing initial centroids for the K-Means algorithm
+     * Allocates memory to store partial results of computing initial centroids for K-Means algorithm
      * \param[in] input     Pointer to the input structure
      * \param[in] parameter Pointer to the parameter structure
      * \param[in] method    Computation method of the algorithm
@@ -376,27 +374,27 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Returns a partial result of computing initial centroids for the K-Means algorithm
+     * Returns a partial result of computing initial centroids for K-Means algorithm
      * \param[in] id   Identifier of the partial result
      * \return         Partial result that corresponds to the given identifier
      */
     data_management::NumericTablePtr get(PartialResultId id) const;
 
     /**
-     * Sets a partial result of computing initial centroids for the K-Means algorithm
+     * Sets a partial result of computing initial centroids for K-Means algorithm
      * \param[in] id    Identifier of the partial result
      * \param[in] ptr   Pointer to the object
      */
     void set(PartialResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-     * Returns the number of features in the result table of the K-Means algorithm
-     * \return Number of features in the result table of the K-Means algorithm
+     * Returns the number of features in the result table of K-Means algorithm
+     * \return Number of features in the result table of K-Means algorithm
      */
     size_t getNumberOfFeatures() const;
 
     /**
-     * Checks a partial result of computing initial centroids for the K-Means algorithm
+     * Checks a partial result of computing initial centroids for K-Means algorithm
      * \param[in] input   %Input object for the algorithm
      * \param[in] par     %Parameter of the algorithm
      * \param[in] method  Computation method of the algorithm
@@ -404,7 +402,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks a partial result of computing initial centroids for the K-Means algorithm
+     * Checks a partial result of computing initial centroids for K-Means algorithm
      * \param[in] par     %Parameter of the algorithm
      * \param[in] method  Computation method of the algorithm
      */
@@ -423,7 +421,7 @@ typedef services::SharedPtr<PartialResult> PartialResultPtr;
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__RESULT"></a>
  * \brief Results obtained with the compute() method that computes initial centroids
- *  for the K-Means algorithm in the batch processing mode
+ *  for K-Means algorithm in the batch processing mode
  */
 class DAAL_EXPORT Result : public daal::algorithms::Result
 {
@@ -434,7 +432,7 @@ public:
     virtual ~Result() {};
 
     /**
-     * Allocates memory to store the results of computing initial centroids for the K-Means algorithm
+     * Allocates memory to store the results of computing initial centroids for K-Means algorithm
      * \param[in] input        Pointer to the input structure
      * \param[in] parameter    Pointer to the parameter structure
      * \param[in] method       Computation method of the algorithm
@@ -443,7 +441,7 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Allocates memory to store the results of computing initial centroids for the K-Means algorithm
+     * Allocates memory to store the results of computing initial centroids for K-Means algorithm
      * \param[in] partialResult Pointer to the partial result structure
      * \param[in] parameter     Pointer to the parameter structure
      * \param[in] method        Computation method of the algorithm
@@ -452,21 +450,21 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::PartialResult *partialResult, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Returns the result of computing initial centroids for the K-Means algorithm
+     * Returns the result of computing initial centroids for K-Means algorithm
      * \param[in] id   Identifier of the result
      * \return         Result that corresponds to the given identifier
      */
     data_management::NumericTablePtr get(ResultId id) const;
 
     /**
-     * Sets the result of computing initial centroids for the K-Means algorithm
+     * Sets the result of computing initial centroids for K-Means algorithm
      * \param[in] id    Identifier of the result
      * \param[in] ptr   Pointer to the object
      */
     void set(ResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-     * Checks the result of computing initial centroids for the K-Means algorithm
+     * Checks the result of computing initial centroids for K-Means algorithm
      * \param[in] input   %Input object for the algorithm
      * \param[in] par     %Parameter of the algorithm
      * \param[in] method  Computation method of the algorithm
@@ -474,7 +472,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks the result of computing initial centroids for the K-Means algorithm
+     * Checks the result of computing initial centroids for K-Means algorithm
      * \param[in] pres    Partial results of the algorithm
      * \param[in] par     %Parameter of the algorithm
      * \param[in] method  Computation method of the algorithm
@@ -493,7 +491,7 @@ typedef services::SharedPtr<Result> ResultPtr;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2MASTERINPUT"></a>
- * \brief %Input objects for computing initials clusters for the K-Means
+ * \brief %Input objects for computing initials clusters for K-Means
  *  algorithm in the second step of the distributed processing mode
  */
 class DAAL_EXPORT DistributedStep2MasterInput : public InputIface
@@ -504,7 +502,7 @@ public:
     virtual ~DistributedStep2MasterInput() {}
 
     /**
-     * Returns an input object for computing initial centroids for the K-Means algorithm
+     * Returns an input object for computing initial centroids for K-Means algorithm
      * in the second step of the distributed processing mode
      * \param[in] id    Identifier of the input object
      * \return          %Input object that corresponds to the given identifier
@@ -512,7 +510,7 @@ public:
     data_management::DataCollectionPtr get(DistributedStep2MasterInputId id) const;
 
     /**
-     * Sets an input object for computing initial centroids for the K-Means algorithm
+     * Sets an input object for computing initial centroids for K-Means algorithm
      * in the second step of the distributed processing mode
      * \param[in] id    Identifier of the input object
      * \param[in] ptr   Pointer to the object
@@ -520,7 +518,7 @@ public:
     void set(DistributedStep2MasterInputId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-     * Adds a value to the data collection of input objects for computing initial centroids for the K-Means algorithm
+     * Adds a value to the data collection of input objects for computing initial centroids for K-Means algorithm
      * in the second step of the distributed processing mode
      * \param[in] id    Identifier of the parameter
      * \param[in] value Pointer to the new parameter value
@@ -534,7 +532,7 @@ public:
     size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks an input object for computing initial centroids for the K-Means algorithm
+     * Checks an input object for computing initial centroids for K-Means algorithm
      * in the second step of the distributed processing mode
      * \param[in] par     %Parameter of the algorithm
      * \param[in] method  Computation method of the algorithm
@@ -544,7 +542,7 @@ public:
 
 /**
 * <a name="DAAL-STRUCT-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSPARAMETER"></a>
-* \brief Parameters for computing initial centroids for the K-Means algorithm
+* \brief Parameters for computing initial centroids for K-Means algorithm
 */
 struct DAAL_EXPORT DistributedStep2LocalPlusPlusParameter : public Parameter
 {
@@ -554,9 +552,9 @@ struct DAAL_EXPORT DistributedStep2LocalPlusPlusParameter : public Parameter
     DistributedStep2LocalPlusPlusParameter(size_t _nClusters, bool bFirstIteration);
 
     /**
-    * Constructs parameters of the algorithm that computes initial centroids for the K-Means algorithm
+    * Constructs parameters of the algorithm that computes initial centroids for K-Means algorithm
     * by copying another parameters object
-    * \param[in] other    Parameters of the K-Means algorithm
+    * \param[in] other    Parameters of K-Means algorithm
     */
     DistributedStep2LocalPlusPlusParameter(const DistributedStep2LocalPlusPlusParameter &other);
 
@@ -567,7 +565,7 @@ struct DAAL_EXPORT DistributedStep2LocalPlusPlusParameter : public Parameter
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSINPUT"></a>
-* \brief Interface for the K-Means initialization distributed Input classes
+* \brief Interface for K-Means initialization distributed Input classes
 *        used with plusPlus and parallelPlus methods only on the 2nd step on a local node.
 */
 class DAAL_EXPORT DistributedStep2LocalPlusPlusInput : public Input
@@ -579,49 +577,49 @@ public:
     virtual ~DistributedStep2LocalPlusPlusInput() {}
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(InputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(InputId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::DataCollectionPtr get(DistributedLocalPlusPlusInputDataId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(DistributedLocalPlusPlusInputDataId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(DistributedStep2LocalPlusPlusInputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(DistributedStep2LocalPlusPlusInputId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks an input object for computing initial centroids for the K-Means algorithm
+    * Checks an input object for computing initial centroids for K-Means algorithm
     * \param[in] par     %Input object
     * \param[in] method  Method of the algorithm
     */
@@ -630,7 +628,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP3MASTERPLUSPLUSINPUT"></a>
-* \brief Interface for the K-Means distributed Input classes
+* \brief Interface for K-Means distributed Input classes
 *        used with plusPlus and parallelPlus methods only on the 3rd step on a master node.
 */
 class DAAL_EXPORT DistributedStep3MasterPlusPlusInput : public daal::algorithms::Input
@@ -640,21 +638,21 @@ public:
     DistributedStep3MasterPlusPlusInput(const DistributedStep3MasterPlusPlusInput& o);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::KeyValueDataCollectionPtr get(DistributedStep3MasterPlusPlusInputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(DistributedStep3MasterPlusPlusInputId id, const data_management::KeyValueDataCollectionPtr &ptr);
 
     /**
-    * Add an input object for computing initial centroids for the K-Means algorithm
+    * Add an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] key   Identifier of the node this object comes from
     * \param[in] ptr   Pointer to the input object
@@ -662,7 +660,7 @@ public:
     void add(DistributedStep3MasterPlusPlusInputId id, size_t key, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks an input object for computing initial centroids for the K-Means algorithm
+    * Checks an input object for computing initial centroids for K-Means algorithm
     * \param[in] par     %Input object
     * \param[in] method  Method of the algorithm
     */
@@ -671,7 +669,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP4LOCALPLUSPLUSINPUT"></a>
-* \brief Interface for the K-Means distributed Input classes
+* \brief Interface for K-Means distributed Input classes
 *        used with plusPlus and parallelPlus methods only on the 4th step on a local node.
 */
 class DAAL_EXPORT DistributedStep4LocalPlusPlusInput : public Input
@@ -681,49 +679,49 @@ public:
     DistributedStep4LocalPlusPlusInput(const DistributedStep4LocalPlusPlusInput& o);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(InputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(InputId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::DataCollectionPtr get(DistributedLocalPlusPlusInputDataId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(DistributedLocalPlusPlusInputDataId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-    * Returns input objects for computing initial centroids for the K-Means algorithm
+    * Returns input objects for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(DistributedStep4LocalPlusPlusInputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the input object
     */
     void set(DistributedStep4LocalPlusPlusInputId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks an input object for computing initial centroids for the K-Means algorithm
+    * Checks an input object for computing initial centroids for K-Means algorithm
     * \param[in] par     %Input object
     * \param[in] method  Method of the algorithm
     */
@@ -732,7 +730,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP5MASTERPLUSPLUSINPUT"></a>
-* \brief Interface for the K-Means distributed Input classes
+* \brief Interface for K-Means distributed Input classes
 */
 class DAAL_EXPORT DistributedStep5MasterPlusPlusInput : public daal::algorithms::Input
 {
@@ -743,7 +741,7 @@ public:
     virtual ~DistributedStep5MasterPlusPlusInput() {}
 
     /**
-    * Returns an input object for computing initial centroids for the K-Means algorithm
+    * Returns an input object for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
@@ -751,7 +749,7 @@ public:
     data_management::DataCollectionPtr get(DistributedStep5MasterPlusPlusInputId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the object
@@ -759,7 +757,7 @@ public:
     void set(DistributedStep5MasterPlusPlusInputId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-    * Adds a value to the data collection of input objects for computing initial centroids for the K-Means algorithm
+    * Adds a value to the data collection of input objects for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] id    Identifier of the parameter
     * \param[in] value Pointer to the new parameter value
@@ -767,7 +765,7 @@ public:
     void add(DistributedStep5MasterPlusPlusInputId id, const data_management::NumericTablePtr &value);
 
     /**
-    * Returns an input object for computing initial centroids for the K-Means algorithm
+    * Returns an input object for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] id    Identifier of the input object
     * \return          %Input object that corresponds to the given identifier
@@ -775,7 +773,7 @@ public:
     data_management::SerializationIfacePtr get(DistributedStep5MasterPlusPlusInputDataId id) const;
 
     /**
-    * Sets an input object for computing initial centroids for the K-Means algorithm
+    * Sets an input object for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] id    Identifier of the input object
     * \param[in] ptr   Pointer to the object
@@ -783,7 +781,7 @@ public:
     void set(DistributedStep5MasterPlusPlusInputDataId id, const data_management::SerializationIfacePtr &ptr);
 
     /**
-    * Checks an input object for computing initial centroids for the K-Means algorithm
+    * Checks an input object for computing initial centroids for K-Means algorithm
     * in the 5th step of the distributed processing mode
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
@@ -793,7 +791,7 @@ public:
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP2LOCALPLUSPLUSPARTIALRESULT"></a>
-* \brief Partial results obtained with the compute() method of the K-Means algorithm in the distributed processing mode
+* \brief Partial results obtained with the compute() method of K-Means algorithm in the distributed processing mode
 */
 class DAAL_EXPORT DistributedStep2LocalPlusPlusPartialResult : public daal::algorithms::PartialResult
 {
@@ -804,7 +802,7 @@ public:
     virtual ~DistributedStep2LocalPlusPlusPartialResult() {};
 
     /**
-    * Allocates memory to store partial results of computing initial centroids for the K-Means algorithm
+    * Allocates memory to store partial results of computing initial centroids for K-Means algorithm
     * \param[in] input     Pointer to the input structure
     * \param[in] parameter Pointer to the parameter structure
     * \param[in] method    Computation method of the algorithm
@@ -813,35 +811,35 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(DistributedStep2LocalPlusPlusPartialResultId id) const;
 
     /**
-    * Sets a partial result of computing initial centroids for the K-Means algorithm
+    * Sets a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the partial result
     * \param[in] ptr   Pointer to the object
     */
     void set(DistributedStep2LocalPlusPlusPartialResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::DataCollectionPtr get(DistributedStep2LocalPlusPlusPartialResultDataId id) const;
 
     /**
-    * Sets a partial result of computing initial centroids for the K-Means algorithm
+    * Sets a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the partial result
     * \param[in] ptr   Pointer to the object
     */
     void set(DistributedStep2LocalPlusPlusPartialResultDataId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] input   %Input object for the algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
@@ -849,7 +847,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
     */
@@ -876,7 +874,7 @@ typedef services::SharedPtr<DistributedStep2LocalPlusPlusPartialResult> Distribu
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP3MASTERPLUSPLUSPARTIALRESULT"></a>
-* \brief Partial results obtained with the compute() method of the K-Means algorithm in the distributed processing mode
+* \brief Partial results obtained with the compute() method of K-Means algorithm in the distributed processing mode
 */
 class DAAL_EXPORT DistributedStep3MasterPlusPlusPartialResult : public daal::algorithms::PartialResult
 {
@@ -887,7 +885,7 @@ public:
     virtual ~DistributedStep3MasterPlusPlusPartialResult() {};
 
     /**
-    * Allocates memory to store partial results of computing initial centroids for the K-Means algorithm
+    * Allocates memory to store partial results of computing initial centroids for K-Means algorithm
     * \param[in] input     Pointer to the input structure
     * \param[in] parameter Pointer to the parameter structure
     * \param[in] method    Computation method of the algorithm
@@ -896,14 +894,14 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::KeyValueDataCollectionPtr get(DistributedStep3MasterPlusPlusPartialResultId id) const;
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \param[in] key  Identifier of the node this partial result comes from
     * \return         Partial result that corresponds to the given identifier
@@ -911,14 +909,14 @@ public:
     data_management::NumericTablePtr get(DistributedStep3MasterPlusPlusPartialResultId id, size_t key) const;
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::SerializationIfacePtr get(DistributedStep3MasterPlusPlusPartialResultDataId id) const;
 
     /**
-    * Sets a partial result of computing initial centroids for the K-Means algorithm
+    * Sets a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the partial result
     * \param[in] key   Identifier of the node this partial result comes from
     * \param[in] ptr   Pointer to the object
@@ -926,7 +924,7 @@ public:
     void add(DistributedStep3MasterPlusPlusPartialResultId id, size_t key, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] input   %Input object for the algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
@@ -934,7 +932,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
     */
@@ -961,7 +959,7 @@ typedef services::SharedPtr<DistributedStep3MasterPlusPlusPartialResult> Distrib
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP4LOCALPLUSPLUSPARTIALRESULT"></a>
-* \brief Partial results obtained with the compute() method of the K-Means algorithm in the distributed processing mode
+* \brief Partial results obtained with the compute() method of K-Means algorithm in the distributed processing mode
 */
 class DAAL_EXPORT DistributedStep4LocalPlusPlusPartialResult : public daal::algorithms::PartialResult
 {
@@ -972,7 +970,7 @@ public:
     virtual ~DistributedStep4LocalPlusPlusPartialResult() {};
 
     /**
-    * Allocates memory to store partial results of computing initial centroids for the K-Means algorithm
+    * Allocates memory to store partial results of computing initial centroids for K-Means algorithm
     * \param[in] input     Pointer to the input structure
     * \param[in] parameter Pointer to the parameter structure
     * \param[in] method    Computation method of the algorithm
@@ -981,21 +979,21 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(DistributedStep4LocalPlusPlusPartialResultId id) const;
 
     /**
-    * Sets a partial result of computing initial centroids for the K-Means algorithm
+    * Sets a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the partial result
     * \param[in] ptr   Pointer to the object
     */
     void set(DistributedStep4LocalPlusPlusPartialResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] input   %Input object for the algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
@@ -1003,7 +1001,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
     */
@@ -1022,7 +1020,7 @@ typedef services::SharedPtr<DistributedStep4LocalPlusPlusPartialResult> Distribu
 
 /**
 * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INIT__DISTRIBUTEDSTEP5MASTERPLUSPLUSPARTIALRESULT"></a>
-* \brief Partial results obtained with the compute() method of the K-Means algorithm in the distributed processing mode
+* \brief Partial results obtained with the compute() method of K-Means algorithm in the distributed processing mode
 */
 class DAAL_EXPORT DistributedStep5MasterPlusPlusPartialResult : public daal::algorithms::PartialResult
 {
@@ -1033,7 +1031,7 @@ public:
     virtual ~DistributedStep5MasterPlusPlusPartialResult() {};
 
     /**
-    * Allocates memory to store partial results of computing initial centroids for the K-Means algorithm
+    * Allocates memory to store partial results of computing initial centroids for K-Means algorithm
     * \param[in] input     Pointer to the input structure
     * \param[in] parameter Pointer to the parameter structure
     * \param[in] method    Computation method of the algorithm
@@ -1042,21 +1040,21 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-    * Returns a partial result of computing initial centroids for the K-Means algorithm
+    * Returns a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id   Identifier of the partial result
     * \return         Partial result that corresponds to the given identifier
     */
     data_management::NumericTablePtr get(DistributedStep5MasterPlusPlusPartialResultId id) const;
 
     /**
-    * Sets a partial result of computing initial centroids for the K-Means algorithm
+    * Sets a partial result of computing initial centroids for K-Means algorithm
     * \param[in] id    Identifier of the partial result
     * \param[in] ptr   Pointer to the object
     */
     void set(DistributedStep5MasterPlusPlusPartialResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] input   %Input object for the algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
@@ -1064,7 +1062,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-    * Checks a partial result of computing initial centroids for the K-Means algorithm
+    * Checks a partial result of computing initial centroids for K-Means algorithm
     * \param[in] par     %Parameter of the algorithm
     * \param[in] method  Computation method of the algorithm
     */
@@ -1087,21 +1085,20 @@ namespace interface2
 {
 /**
  * <a name="DAAL-STRUCT-ALGORITHMS__KMEANS__INIT__BATCH__PARAMETER"></a>
- * \brief Parameters for computing initial centroids for the K-Means algorithm of the batch mode
+ * \brief Parameters for computing initial centroids for K-Means algorithm of the batch mode
  */
 struct DAAL_EXPORT Parameter : public interface1::Parameter
 {
     Parameter(size_t _nClusters, size_t _offset = 0, size_t _seed = 777777);
 
     /**
-     * Constructs parameters of the algorithm that computes initial centroids for the K-Means algorithm
+     * Constructs parameters of the algorithm that computes initial centroids for K-Means algorithm
      * by copying another parameters object
-     * \param[in] other    Parameters of the K-Means algorithm
+     * \param[in] other    Parameters of K-Means algorithm
      */
     Parameter(const Parameter &other);
 
-    size_t nTrials;     /*!< Kmeans++ only. The number of trials to generate all clusters but the first initial cluster.
-                                            See section (5) of [1] */
+    size_t nTrials;     /*!< Kmeans++ only. The number of trials to generate all clusters but the first initial cluster. */
 
     services::Status check() const DAAL_C11_OVERRIDE;
 };

--- a/include/algorithms/kmeans/kmeans_types.h
+++ b/include/algorithms/kmeans/kmeans_types.h
@@ -17,7 +17,7 @@
 
 /*
 //++
-//  Implementation of the K-Means algorithm interface.
+//  Implementation of K-Means algorithm interface.
 //--
 */
 
@@ -39,12 +39,12 @@ namespace algorithms
  * @ingroup kmeans
  * @{
  */
-/** \brief Contains classes of the K-Means algorithm */
+/** \brief Contains classes of K-Means algorithm */
 namespace kmeans
 {
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__METHOD"></a>
- * Available methods of the K-Means algorithm
+ * Available methods of K-Means algorithm
  */
 enum Method
 {
@@ -65,7 +65,7 @@ enum DistanceType
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__INPUTID"></a>
- * \brief Available identifiers of input objects for the K-Means algorithm
+ * \brief Available identifiers of input objects for K-Means algorithm
  */
 enum InputId
 {
@@ -76,7 +76,7 @@ enum InputId
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__MASTERINPUTID"></a>
- * \brief Available identifiers of input objects for the K-Means algorithm in the distributed processing mode
+ * \brief Available identifiers of input objects for K-Means algorithm in the distributed processing mode
  */
 enum MasterInputId
 {
@@ -86,7 +86,7 @@ enum MasterInputId
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__PARTIALRESULTID"></a>
- * \brief Available identifiers of partial results of the K-Means algorithm in the distributed processing mode
+ * \brief Available identifiers of partial results of K-Means algorithm in the distributed processing mode
  */
 enum PartialResultId
 {
@@ -102,7 +102,7 @@ enum PartialResultId
 
 /**
  * <a name="DAAL-ENUM-ALGORITHMS__KMEANS__RESULTID"></a>
- * \brief Available identifiers of results of the K-Means algorithm
+ * \brief Available identifiers of results of K-Means algorithm
  */
 enum ResultId
 {
@@ -121,7 +121,7 @@ namespace interface1
 {
 /**
  * <a name="DAAL-STRUCT-ALGORITHMS__KMEANS__PARAMETER"></a>
- * \brief Parameters for the K-Means algorithm
+ * \brief Parameters for K-Means algorithm
  * \par Enumerations
  *      - \ref DistanceType Methods for distance computation
  *
@@ -131,15 +131,15 @@ namespace interface1
 struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
 {
     /**
-     *  Constructs parameters of the K-Means algorithm
+     *  Constructs parameters of K-Means algorithm
      *  \param[in] _nClusters   Number of clusters
      *  \param[in] _maxIterations Number of iterations
      */
     Parameter(size_t _nClusters, size_t _maxIterations);
 
     /**
-     *  Constructs parameters of the K-Means algorithm by copying another parameters of the K-Means algorithm
-     *  \param[in] other    Parameters of the K-Means algorithm
+     *  Constructs parameters of K-Means algorithm by copying another parameters of K-Means algorithm
+     *  \param[in] other    Parameters of K-Means algorithm
      */
     Parameter(const Parameter &other);
 
@@ -156,7 +156,7 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INPUTIFACE"></a>
- * \brief Interface for input objects for the the K-Means algorithm in the batch and distributed processing modes
+ * \brief Interface for input objects for K-Means algorithm in the batch and distributed processing modes
  */
 class DAAL_EXPORT InputIface : public daal::algorithms::Input
 {
@@ -168,7 +168,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__INPUT"></a>
- * \brief %Input objects for the K-Means algorithm
+ * \brief %Input objects for K-Means algorithm
  */
 class DAAL_EXPORT Input : public InputIface
 {
@@ -177,14 +177,14 @@ public:
     virtual ~Input() {}
 
     /**
-     * Returns an input object for the K-Means algorithm
+     * Returns an input object for K-Means algorithm
      * \param[in] id    Identifier of the input object
      * \return          %Input object that corresponds to the given identifier
      */
     data_management::NumericTablePtr get(InputId id) const;
 
     /**
-     * Sets an input object for the K-Means algorithm
+     * Sets an input object for K-Means algorithm
      * \param[in] id    Identifier of the input object
      * \param[in] ptr   Pointer to the object
      */
@@ -198,7 +198,7 @@ public:
     size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks input objects for the K-Means algorithm
+     * Checks input objects for K-Means algorithm
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method of the algorithm
      */
@@ -207,7 +207,7 @@ public:
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__PARTIALRESULT"></a>
- * \brief Partial results obtained with the compute() method of the K-Means algorithm in the batch processing mode
+ * \brief Partial results obtained with the compute() method of K-Means algorithm in the batch processing mode
  */
 class DAAL_EXPORT PartialResult : public daal::algorithms::PartialResult
 {
@@ -218,7 +218,7 @@ public:
     virtual ~PartialResult() {};
 
     /**
-     * Allocates memory to store partial results of the K-Means algorithm
+     * Allocates memory to store partial results of K-Means algorithm
      * \param[in] input        Pointer to the structure of the input objects
      * \param[in] parameter    Pointer to the structure of the algorithm parameters
      * \param[in] method       Computation method of the algorithm
@@ -227,14 +227,14 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Returns a partial result of the K-Means algorithm
+     * Returns a partial result of K-Means algorithm
      * \param[in] id   Identifier of the partial result
      * \return         Partial result that corresponds to the given identifier
      */
     data_management::NumericTablePtr get(PartialResultId id) const;
 
     /**
-     * Sets a partial result of the K-Means algorithm
+     * Sets a partial result of K-Means algorithm
      * \param[in] id    Identifier of the partial result
      * \param[in] ptr   Pointer to the object
      */
@@ -248,7 +248,7 @@ public:
     size_t getNumberOfFeatures() const;
 
     /**
-     * Checks partial results of the K-Means algorithm
+     * Checks partial results of K-Means algorithm
      * \param[in] input   %Input object of the algorithm
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method
@@ -256,7 +256,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks partial results of the K-Means algorithm
+     * Checks partial results of K-Means algorithm
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method
      */
@@ -274,7 +274,7 @@ typedef services::SharedPtr<PartialResult> PartialResultPtr;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__RESULT"></a>
- * \brief Results obtained with the compute() method of the K-Means algorithm in the batch processing mode
+ * \brief Results obtained with the compute() method of K-Means algorithm in the batch processing mode
  */
 class DAAL_EXPORT Result : public daal::algorithms::Result
 {
@@ -285,7 +285,7 @@ public:
     virtual ~Result() {};
 
     /**
-     * Allocates memory to store the results of the K-Means algorithm
+     * Allocates memory to store the results of K-Means algorithm
      * \param[in] input     Pointer to the structure of the input objects
      * \param[in] parameter Pointer to the structure of the algorithm parameters
      * \param[in] method    Computation method
@@ -294,7 +294,7 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::Input *input, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Allocates memory to store the results of the K-Means algorithm
+     * Allocates memory to store the results of K-Means algorithm
      * \param[in] partialResult Pointer to the partial result structure
      * \param[in] parameter     Pointer to the structure of the algorithm parameters
      * \param[in] method        Computation method
@@ -303,21 +303,21 @@ public:
     DAAL_EXPORT services::Status allocate(const daal::algorithms::PartialResult *partialResult, const daal::algorithms::Parameter *parameter, const int method);
 
     /**
-     * Returns the result of the K-Means algorithm
+     * Returns the result of K-Means algorithm
      * \param[in] id   Result identifier
      * \return         Result that corresponds to the given identifier
      */
     data_management::NumericTablePtr get(ResultId id) const;
 
     /**
-     * Sets the result of the K-Means algorithm
+     * Sets the result of K-Means algorithm
      * \param[in] id    Identifier of the result
      * \param[in] ptr   Pointer to the object
      */
     void set(ResultId id, const data_management::NumericTablePtr &ptr);
 
     /**
-     * Checks the result of the K-Means algorithm
+     * Checks the result of K-Means algorithm
      * \param[in] input   %Input objects for the algorithm
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method
@@ -325,7 +325,7 @@ public:
     services::Status check(const daal::algorithms::Input *input, const daal::algorithms::Parameter *par, int method) const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks the results of the K-Means algorithm
+     * Checks the results of K-Means algorithm
      * \param[in] pres    Partial results of the algorithm
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method
@@ -344,7 +344,7 @@ typedef services::SharedPtr<Result> ResultPtr;
 
 /**
  * <a name="DAAL-CLASS-ALGORITHMS__KMEANS__DISTRIBUTEDSTEP2MASTERINPUT"></a>
- * \brief %Input objects for the K-Means algorithm in the distributed processing mode
+ * \brief %Input objects for K-Means algorithm in the distributed processing mode
  */
 class DAAL_EXPORT DistributedStep2MasterInput : public InputIface
 {
@@ -354,21 +354,21 @@ public:
     virtual ~DistributedStep2MasterInput() {}
 
     /**
-     * Returns an input object for the K-Means algorithm in the second step of the distributed processing mode
+     * Returns an input object for K-Means algorithm in the second step of the distributed processing mode
      * \param[in] id    Identifier of the input object
      * \return          %Input object that corresponds to the given identifier
      */
     data_management::DataCollectionPtr get(MasterInputId id) const;
 
     /**
-     * Sets an input object for the K-Means algorithm in the second step of the distributed processing mode
+     * Sets an input object for K-Means algorithm in the second step of the distributed processing mode
      * \param[in] id    Identifier of the input object
      * \param[in] ptr   Pointer to the object
      */
     void set(MasterInputId id, const data_management::DataCollectionPtr &ptr);
 
     /**
-     * Adds partial results computed on local nodes to the input for the K-Means algorithm
+     * Adds partial results computed on local nodes to the input for K-Means algorithm
      * in the second step of the distributed processing mode
      * \param[in] id    Identifier of the input object
      * \param[in] value Pointer to the object
@@ -383,7 +383,7 @@ public:
     size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE;
 
     /**
-     * Checks an input object for the K-Means algorithm in the second step of the distributed processing mode
+     * Checks an input object for K-Means algorithm in the second step of the distributed processing mode
      * \param[in] par     Algorithm parameter
      * \param[in] method  Computation method
      */


### PR DESCRIPTION
Changes in doxygen comments for K-Means header files:

- Removed wrong references "See section..."
- Removed all the articles before "K-Means algorithm"