### PR TITLE
Fix nullptr dereference if not ok

### DIFF
--- a/algorithms/kernel/assocrules/assoc_rules_apriori_mine_impl.i
+++ b/algorithms/kernel/assocrules/assoc_rules_apriori_mine_impl.i
@@ -197,9 +197,9 @@ bool AssociationRulesKernel<apriori, algorithmFPType, cpu>::genCandidates(size_t
 
                 if (!ai->ok())
                 {
+                    outputStatus = ai->getLastStatus();
                     delete ai;
                     ai = nullptr;
-                    outputStatus = ai->getLastStatus();
                     return false;
                 }
 


### PR DESCRIPTION
If not ok, then we should read status first, after than we should remove object. Not vice-verse.