### PR TITLE
throwIfPossible usage flaws fix

### DIFF
--- a/include/algorithms/linear_regression/linear_regression_model_builder.h
+++ b/include/algorithms/linear_regression/linear_regression_model_builder.h
@@ -109,7 +109,9 @@ public:
         else
         {
             _s = services::Status(services::ErrorIncorrectParameter);
+            _modelPtr->getBeta()->releaseBlockOfRows(pBlock);
             services::throwIfPossible(_s);
+            return;
         }
         _modelPtr->getBeta()->releaseBlockOfRows(pBlock);
     }

--- a/include/algorithms/logistic_regression/logistic_regression_model_builder.h
+++ b/include/algorithms/logistic_regression/logistic_regression_model_builder.h
@@ -112,7 +112,9 @@ public:
         else
         {
             _s = services::Status(services::ErrorIncorrectParameter);
+            _modelPtr->getBeta()->releaseBlockOfRows(pBlock);
             services::throwIfPossible(_s);
+            return;
         }
         _modelPtr->getBeta()->releaseBlockOfRows(pBlock);
     }

--- a/include/algorithms/multi_class_classifier/multi_class_classifier_model_builder.h
+++ b/include/algorithms/multi_class_classifier/multi_class_classifier_model_builder.h
@@ -84,9 +84,14 @@ public:
     {
         if(negativeClassIdx >= positiveClassIdx)
         {
-            _s = services::Status(services::ErrorIncorrectParameter);
+            _s |= services::Status(services::ErrorIncorrectParameter);
         }
-        services::throwIfPossible(_s);
+
+        if(!_s)
+        {
+            services::throwIfPossible(_s);
+            return;
+        }
         size_t imodel = positiveClassIdx * (positiveClassIdx - 1)/2 + negativeClassIdx;
 
         _modelPtr->setTwoClassClassifierModel(imodel, model);

--- a/include/data_management/data_source/modifiers/csv/internal/default_modifiers.h
+++ b/include/data_management/data_source/modifiers/csv/internal/default_modifiers.h
@@ -168,6 +168,7 @@ public:
         if ( !_primitives.data() )
         {
             services::throwIfPossible(services::ErrorMemoryAllocationFailed);
+            return;
         }
 
         for (size_t i = 0; i < numberOfInputFeatures; i++)
@@ -220,6 +221,7 @@ public:
             if ( !_primitives.push_back(primitive) )
             {
                 services::throwIfPossible(services::ErrorMemoryAllocationFailed);
+                return;
             }
 
             primitive->initialize(config, i);


### PR DESCRIPTION
I spotted several places where using throwIfPossible leads to unexpected behaviour if exceptions are: disabled(3 places, 2 files with +return); enabled(shall we release block in this case). 
But I'm not quite sure. Could you please help me figure out ;)