### PR TITLE
errorID fixed collision, backward compatible fix

### DIFF
--- a/include/services/error_indexes.h
+++ b/include/services/error_indexes.h
@@ -145,7 +145,7 @@ enum ErrorID
     ErrorBufferSizeIntegerOverflow = -80,                               /*!< Integer oveflow is occured during buffer size calculation */
 
     // Environment errors: -2000..-2999
-    ErrorCpuIsInvalid = -1,                                             /*!< Invalid CPU value used */
+    ErrorCpuIsInvalid = -2999,                                          /*!< Invalid CPU value used */
     ErrorCpuNotSupported = -2000,                                       /*!< CPU not supported */
     ErrorMemoryAllocationFailed = -2001,                                /*!< Memory allocation failed */
     ErrorEmptyDataBlock = -2004,                                        /*!< Empty data block */

--- a/service/kernel/error_handling.cpp
+++ b/service/kernel/error_handling.cpp
@@ -710,6 +710,7 @@ void ErrorMessageCollection::parseResourceFile()
     add(ErrorBufferSizeIntegerOverflow, "Integer overflow is occured");
 
     // Environment errors: -2000..-2999
+    add(ErrorCpuIsInvalid, "CPU is invalid");
     add(ErrorCpuNotSupported, "CPU not supported");
     add(ErrorMemoryAllocationFailed, "Memory allocation failed");
     add(ErrorEmptyDataBlock, "Empty data block");


### PR DESCRIPTION
This fix should remove collision with ErrorMethodNotSupported(-1) error.
Picked value are belong to announced range [-2k..-2999] and didn't move all previous values.
Old user's code still have -1 as a error value which leads to not right error message in parseResourceFile function in cpp file which doesn't change code behaviour in case of dynamic linkage.