### PR TITLE
Fix of probabilities calculation in binary log regression

### DIFF
--- a/algorithms/kernel/logistic_regression/logistic_regression_predict_container.h
+++ b/algorithms/kernel/logistic_regression/logistic_regression_predict_container.h
@@ -94,7 +94,6 @@ services::Status BatchContainer<algorithmFPType, method, cpu>::compute()
         __DAAL_CALL_KERNEL(env, internal::PredictBatchKernelOneAPI, __DAAL_KERNEL_ARGUMENTS(algorithmFPType, method), compute,
             daal::services::internal::hostApp(*input), a, m, par->nClasses, r, prob, logProb);
     }
-
 }
 
 }

--- a/algorithms/kernel/objective_function/logistic_loss/oneapi/cl_kernel/logistic_loss_dense_default.cl
+++ b/algorithms/kernel/objective_function/logistic_loss/oneapi/cl_kernel/logistic_loss_dense_default.cl
@@ -62,13 +62,27 @@ __kernel void logLoss(const __global algorithmFPType* const y,
 }
 
 __kernel void sigmoid(const __global algorithmFPType* const xb,
-  __global algorithmFPType* result, const algorithmFPType expThreshold)
+  const algorithmFPType expThreshold,
+  const uint calculateInverse,
+  __global algorithmFPType* result)
 {
     const uint i = get_global_id(0);
     const algorithmFPType one = (algorithmFPType)1.0;
 
     const algorithmFPType f = fmax(-xb[i], expThreshold);
-    result[i] = one / (one + exp(f));
+    const algorithmFPType p = one / (one + exp(f));
+
+    if (calculateInverse != 0)
+    {
+        const uint firstColIdx = 2*i;
+
+        result[firstColIdx] = one - p;
+        result[firstColIdx+1] = p;
+    }
+    else
+    {
+        result[i] = p;
+    }
 }
 
 __kernel void hessian(const __global algorithmFPType* const x, const uint ldx,

--- a/algorithms/kernel/objective_function/logistic_loss/oneapi/logistic_loss_dense_default_kernel_oneapi.h
+++ b/algorithms/kernel/objective_function/logistic_loss/oneapi/logistic_loss_dense_default_kernel_oneapi.h
@@ -81,7 +81,7 @@ public:
 
     // TODO: move in common services
     static services::Status sigmoids(const services::Buffer<algorithmFPType>& x,
-        services::Buffer<algorithmFPType>& result, const uint32_t n);
+        services::Buffer<algorithmFPType>& result, const uint32_t n, bool calculateInverse = false);
 
     static services::Status betaIntercept(const services::Buffer<algorithmFPType> &arg,
         services::Buffer<algorithmFPType> &x, const uint32_t n);

--- a/algorithms/kernel/objective_function/logistic_loss/oneapi/logistic_loss_dense_default_oneapi_impl.i
+++ b/algorithms/kernel/objective_function/logistic_loss/oneapi/logistic_loss_dense_default_oneapi_impl.i
@@ -159,11 +159,13 @@ services::Status LogLossKernelOneAPI<algorithmFPType, defaultDense>::logLoss(
 }
 
 // sigmoid(x) = 1/(1+exp(-x))
+// if calculateInverse = true, x[i][1] = 1 - sigmoid(x[i][0])
 template <typename algorithmFPType>
 services::Status LogLossKernelOneAPI<algorithmFPType, defaultDense>::sigmoids(
     const services::Buffer<algorithmFPType>& x,
     services::Buffer<algorithmFPType>& result,
-    const uint32_t n)
+    const uint32_t n,
+    bool calculateInverse)
 {
     DAAL_ITTNOTIFY_SCOPED_TASK(sigmoids);
     services::Status status;
@@ -179,10 +181,11 @@ services::Status LogLossKernelOneAPI<algorithmFPType, defaultDense>::sigmoids(
 
     const algorithmFPType expThreshold = math::expThreshold<algorithmFPType>();
 
-    KernelArguments args(3);
+    KernelArguments args(4);
     args.set(0, x, AccessModeIds::read);
-    args.set(1, result, AccessModeIds::write);
-    args.set(2, expThreshold);
+    args.set(1, expThreshold);
+    args.set(2, uint32_t(calculateInverse));
+    args.set(3, result, AccessModeIds::write);
 
     KernelRange range(n);
     {


### PR DESCRIPTION
# Fix of probabilities calculation in binary log regression
In the old version of binary logistic regression for GPU, users can get a probability of the only positive label ("1"). Here I aligned the behavior of this classifier with all other: User can get the probabilities for both two class labels ("0" and "1")

**Private CI**: [link](https://ecmd.inn.intel.com/commander/link/jobDetails/jobs/ea09e3ef-5088-f1d7-bdf6-8cdcd4b723a1?)