### PR TITLE
make tbb threads configurable

### DIFF
--- a/lang_interface/java/com/intel/daal/utils/LibUtils.java
+++ b/lang_interface/java/com/intel/daal/utils/LibUtils.java
@@ -60,7 +60,7 @@ public final class LibUtils{
             }
             String v = System.getProperty("tbb-threads", "");
             int numThreads = v.length()>0 ? Integer.valueOf(v):Runtime.getRuntime().availableProcessors();
-            logger.log("tbb-threads: " + numThreads);
+            logger.log(logLevel, "tbb-threads: " + numThreads);
 
             try {
                 logger.log(logLevel, "Loading library " + DAALLIB + " as file.");

--- a/lang_interface/java/com/intel/daal/utils/LibUtils.java
+++ b/lang_interface/java/com/intel/daal/utils/LibUtils.java
@@ -51,15 +51,15 @@ public final class LibUtils{
      */
     public static void loadLibrary()
     {
-	if(loaded){
-		return;
-	}
+        if(loaded){
+            return;
+        }
         synchronized(LibUtils.class){
             if(loaded){
                 return;
             }
-            String v = System.getProperty("tbb-threads", "1");
-            int numThreads = Integer.valueOf(v);
+            String v = System.getProperty("tbb-threads", "");
+            int numThreads = v.length()>0 ? Integer.valueOf(v):Runtime.getRuntime().availableProcessors();
             logger.log("tbb-threads: " + numThreads);
 
             try {


### PR DESCRIPTION
# Description
make TBB threads configurable so that other resource managers or frameworks, like Spark, can manage resource when use DAAL. What we did is DAAL on Spark. The typical way to run workload on Spark is,
-	break large input into splits
-	one task per split
-	assign one or more CPU cores (cpu_per_task, configurable in Spark) for each task (split)
-	In each worker node, CPU cores are distributed to different executors running on the same node. And each executor could run different number of tasks simultaneously. For example, a executor has 8 cores and cpu_per_task is 2. Then executor can run 4 tasks as same time.
-	Each task invokes DAAL for some algorithms. We don’t’ want DAAL for single task occupy all CPU cores whilst there are other tasks running.

As you can see, it’s the reason why we make TBB threads configurable.


Changes proposed in this pull request:
- load native library only once
- number of TBB threads is configured via system property, "tbb-threads", like below.
  java -Dtbb-threads=10 ...