### PR TITLE
Gradient Boosted Trees performance optimizations

### DIFF
--- a/algorithms/kernel/dtrees/dtrees_feature_type_helper.i
+++ b/algorithms/kernel/dtrees/dtrees_feature_type_helper.i
@@ -193,7 +193,7 @@ template <typename IndexType, typename algorithmFPType, CpuType cpu>
 services::Status ColIndexTaskBins<IndexType, algorithmFPType, cpu>::makeIndex(NumericTable & nt, IndexedFeatures::FeatureEntry & entry,
                                                                               IndexType * aRes, size_t iCol, size_t nRows, bool bUnorderedFeature)
 {
-    if (bUnorderedFeature || nRows <= _prm.maxBins * _prm.minBinSize) return this->makeIndexDefault(nt, entry, aRes, iCol, nRows, bUnorderedFeature);
+    if (bUnorderedFeature || nRows <= _prm.maxBins) return this->makeIndexDefault(nt, entry, aRes, iCol, nRows, bUnorderedFeature);
 
     Status s = this->getSorted(nt, iCol, nRows);
     if (!s) return s;

--- a/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -61,52 +61,130 @@ public:
         TVector<algorithmFPType, cpu, ScalableAllocator<cpu> > aExp(n);
         auto exp                           = aExp.get();
         const algorithmFPType expThreshold = daal::internal::Math<algorithmFPType, cpu>::vExpThreshold();
-        if (sampleInd)
+        const size_t nThreads = daal::threader_get_threads_number();
+        if ( n < getThrOptBorder<cpu>(nThreads) || nThreads <= 1 )
         {
-            PRAGMA_IVDEP
-            PRAGMA_VECTOR_ALWAYS
-            for (size_t i = 0; i < n; ++i)
+            if (sampleInd)
             {
-                exp[i] = -f[sampleInd[i]];
-                /* make all values less than threshold as threshold value
-                to fix slow work on vExp on large negative inputs */
-                if (exp[i] < expThreshold) exp[i] = expThreshold;
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < n; ++i)
+                {
+                    exp[i] = -f[sampleInd[i]];
+                    /* make all values less than threshold as threshold value
+                    to fix slow work on vExp on large negative inputs */
+                    if (exp[i] < expThreshold) exp[i] = expThreshold;
+                }
+            }
+            else
+            {
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < n; ++i)
+                {
+                    exp[i] = -f[i];
+                    /* make all values less than threshold as threshold value
+                    to fix slow work on vExp on large negative inputs */
+                    if (exp[i] < expThreshold) exp[i] = expThreshold;
+                }
+            }
+            daal::internal::Math<algorithmFPType, cpu>::vExp(n, exp, exp);
+            if (sampleInd)
+            {
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < n; ++i)
+                {
+                    const algorithmFPType sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
+                    gh[2 * sampleInd[i]]       = sigm - y[sampleInd[i]];               //gradient
+                    gh[2 * sampleInd[i] + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                }
+            }
+            else
+            {
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < n; ++i)
+                {
+                    const auto sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
+                    gh[2 * i]       =   sigm - y[i];                          //gradient
+                    gh[2 * i + 1]   =   sigm * (algorithmFPType(1.0) - sigm); //hessian
+                }
             }
         }
         else
         {
-            PRAGMA_IVDEP
-            PRAGMA_VECTOR_ALWAYS
-            for (size_t i = 0; i < n; ++i)
+            const size_t nPerBlock = n / nThreads;
+            const size_t nSurplus = n % nThreads;
+            if (sampleInd)
             {
-                exp[i] = -f[i];
-                /* make all values less than threshold as threshold value
-                to fix slow work on vExp on large negative inputs */
-                if (exp[i] < expThreshold) exp[i] = expThreshold;
+                daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
+                {
+                    size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    PRAGMA_IVDEP
+                    PRAGMA_VECTOR_ALWAYS
+                    for (size_t i = start; i < end; i++)
+                    {
+                        exp[i] = -f[sampleInd[i]];
+                        /* make all values less than threshold as threshold value
+                        to fix slow work on vExp on large negative inputs */
+                        if(exp[i] < expThreshold)
+                            exp[i] = expThreshold;
+                    }
+                });
             }
-        }
-        daal::internal::Math<algorithmFPType, cpu>::vExp(n, exp, exp);
+            else
+            {
+                daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
+                {
+                    size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    PRAGMA_IVDEP
+                    PRAGMA_VECTOR_ALWAYS
+                    for (size_t i = start; i < end; i++)
+                    {
+                        exp[i] = -f[i];
+                        /* make all values less than threshold as threshold value
+                        to fix slow work on vExp on large negative inputs */
+                        if(exp[i] < expThreshold)
+                            exp[i] = expThreshold;
+                    }
+                });
+            }
+            daal::internal::Math<algorithmFPType, cpu>::vExp(n, exp, exp);
 
-        if (sampleInd)
-        {
-            PRAGMA_IVDEP
-            PRAGMA_VECTOR_ALWAYS
-            for (size_t i = 0; i < n; ++i)
+            if(sampleInd)
             {
-                const algorithmFPType sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
-                gh[2 * sampleInd[i]]       = sigm - y[sampleInd[i]];               //gradient
-                gh[2 * sampleInd[i] + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
+                {
+                    size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    PRAGMA_IVDEP
+                    PRAGMA_VECTOR_ALWAYS
+                    for (size_t i = start; i < end; i++)
+                    {
+                        const algorithmFPType sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
+                        gh[2 * sampleInd[i]] = sigm - y[sampleInd[i]]; //gradient
+                        gh[2 * sampleInd[i] + 1] = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                    }
+                });
             }
-        }
-        else
-        {
-            PRAGMA_IVDEP
-            PRAGMA_VECTOR_ALWAYS
-            for (size_t i = 0; i < n; ++i)
+            else
             {
-                const auto sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
-                gh[2 * i]       = sigm - y[i];                          //gradient
-                gh[2 * i + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
+                {
+                    size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    PRAGMA_IVDEP
+                    PRAGMA_VECTOR_ALWAYS
+                    for (size_t i = start; i < end; i++)
+                    {
+                        const auto sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
+                        gh[2 * i] = sigm - y[i]; //gradient
+                        gh[2 * i + 1] = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                    }
+                });
             }
         }
     }

--- a/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -63,7 +63,7 @@ public:
         const algorithmFPType expThreshold = daal::internal::Math<algorithmFPType, cpu>::vExpThreshold();
         const size_t nThreads              = daal::threader_get_threads_number();
         const size_t nBlocks               = getNBlocksForOpt<cpu>(nThreads, n);
-        if ( nBlocks == 1 )
+        if (nBlocks == 1)
         {
             if (sampleInd)
             {
@@ -108,21 +108,20 @@ public:
                 for (size_t i = 0; i < n; ++i)
                 {
                     const auto sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
-                    gh[2 * i]       =   sigm - y[i];                          //gradient
-                    gh[2 * i + 1]   =   sigm * (algorithmFPType(1.0) - sigm); //hessian
+                    gh[2 * i]       = sigm - y[i];                          //gradient
+                    gh[2 * i + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
                 }
             }
         }
         else
         {
             const size_t nPerBlock = n / nBlocks;
-            const size_t nSurplus = n % nBlocks;
+            const size_t nSurplus  = n % nBlocks;
             if (sampleInd)
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
@@ -130,18 +129,16 @@ public:
                         exp[i] = -f[sampleInd[i]];
                         /* make all values less than threshold as threshold value
                         to fix slow work on vExp on large negative inputs */
-                        if(exp[i] < expThreshold)
-                            exp[i] = expThreshold;
+                        if (exp[i] < expThreshold) exp[i] = expThreshold;
                     }
                     daal::internal::Math<algorithmFPType, cpu>::vExp(end - start, exp + start, exp + start);
                 });
             }
             else
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
@@ -149,42 +146,39 @@ public:
                         exp[i] = -f[i];
                         /* make all values less than threshold as threshold value
                         to fix slow work on vExp on large negative inputs */
-                        if(exp[i] < expThreshold)
-                            exp[i] = expThreshold;
+                        if (exp[i] < expThreshold) exp[i] = expThreshold;
                     }
                     daal::internal::Math<algorithmFPType, cpu>::vExp(end - start, exp + start, exp + start);
                 });
             }
 
-            if(sampleInd)
+            if (sampleInd)
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
                     {
                         const algorithmFPType sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
-                        gh[2 * sampleInd[i]] = sigm - y[sampleInd[i]]; //gradient
-                        gh[2 * sampleInd[i] + 1] = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                        gh[2 * sampleInd[i]]       = sigm - y[sampleInd[i]];               //gradient
+                        gh[2 * sampleInd[i] + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
                     }
                 });
             }
             else
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
                     {
                         const auto sigm = algorithmFPType(1.0) / (algorithmFPType(1.0) + exp[i]);
-                        gh[2 * i] = sigm - y[i]; //gradient
-                        gh[2 * i + 1] = sigm * (algorithmFPType(1.0) - sigm); //hessian
+                        gh[2 * i]       = sigm - y[i];                          //gradient
+                        gh[2 * i + 1]   = sigm * (algorithmFPType(1.0) - sigm); //hessian
                     }
                 });
             }

--- a/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -65,7 +65,7 @@ public:
         const size_t nBlocks               = getNBlocksForOpt<cpu>(nThreads, n);
         const size_t nPerBlock             = n / nBlocks;
         const size_t nSurplus              = n % nBlocks;
-        const bool inParallel              = nBlocks > 1 ? true : false;
+        const bool inParallel              = nBlocks > 1;
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             const size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
@@ -78,7 +78,8 @@ public:
                     exp[i] = -f[sampleInd[i]];
                     /* make all values less than threshold as threshold value
                     to fix slow work on vExp on large negative inputs */
-                    if (exp[i] < expThreshold) exp[i] = expThreshold;
+                    if (exp[i] < expThreshold)
+                        exp[i] = expThreshold;
                 }
             }
             else
@@ -90,7 +91,8 @@ public:
                     exp[i] = -f[i];
                     /* make all values less than threshold as threshold value
                     to fix slow work on vExp on large negative inputs */
-                    if (exp[i] < expThreshold) exp[i] = expThreshold;
+                    if (exp[i] < expThreshold)
+                        exp[i] = expThreshold;
                 }
             }
             daal::internal::Math<algorithmFPType, cpu>::vExp(end - start, exp + start, exp + start);

--- a/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
@@ -61,10 +61,13 @@ void deleteTables(gbt::internal::GbtDecisionTree ** aTbl, HomogenNumericTable<do
 }
 
 template <CpuType cpu>
-size_t getThrOptBorder(size_t nThreads)
+size_t getNBlocksForOpt(size_t nThreads, size_t n)
 {
-    // TODO: investigate effect of threading optimization on different cpus and numbers of threads
-    return 256000;
+    if ( nThreads <= 1 || n < 128000 ) return 1;
+    const size_t blockSize = 512;
+    size_t nBlocks = n / blockSize;
+    if ( nBlocks % blockSize ) nBlocks++;
+    return nBlocks;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
@@ -60,6 +60,13 @@ void deleteTables(gbt::internal::GbtDecisionTree ** aTbl, HomogenNumericTable<do
     }
 }
 
+template <CpuType cpu>
+size_t getThrOptBorder(size_t nThreads)
+{
+    // TODO: investigate effect of threading optimization on different cpus and numbers of threads
+    return 256000;
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // Data helper class for regression
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_aux.i
@@ -63,10 +63,10 @@ void deleteTables(gbt::internal::GbtDecisionTree ** aTbl, HomogenNumericTable<do
 template <CpuType cpu>
 size_t getNBlocksForOpt(size_t nThreads, size_t n)
 {
-    if ( nThreads <= 1 || n < 128000 ) return 1;
+    if (nThreads <= 1 || n < 128000) return 1;
     const size_t blockSize = 512;
-    size_t nBlocks = n / blockSize;
-    if ( nBlocks % blockSize ) nBlocks++;
+    size_t nBlocks         = n / blockSize;
+    if (nBlocks % blockSize) nBlocks++;
     return nBlocks;
 }
 

--- a/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
@@ -249,7 +249,7 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     const algorithmFPType inc = val * _par.shrinkage;
     const size_t nThreads     = numAvailableThreads();
     const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
-    const bool inParallel     = nBlocks > 1 ? true : false;
+    const bool inParallel     = nBlocks > 1;
     const size_t nPerBlock    = n / nBlocks;
     const size_t nSurplus     = n % nBlocks;
     LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {

--- a/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
@@ -249,11 +249,11 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     const algorithmFPType inc = val * _par.shrinkage;
     const size_t nThreads     = numAvailableThreads();
     const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
-    if ( nBlocks == 1 )
+    if (nBlocks == 1)
     {
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
-        for(size_t i = 0; i < n; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             pf[idx[i] * this->_nTrees + iTree] += inc;
         }
@@ -261,15 +261,13 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     else
     {
         const size_t nPerBlock = n / nBlocks;
-        const size_t nSurplus = n % nBlocks;
-        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-        {
+        const size_t nSurplus  = n % nBlocks;
+        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-            size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+            size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
             PRAGMA_IVDEP
             PRAGMA_VECTOR_ALWAYS
-            for (size_t i = start; i < end; i++)
-                pf[idx[i] * this->_nTrees + iTree] += inc;
+            for (size_t i = start; i < end; i++) pf[idx[i] * this->_nTrees + iTree] += inc;
         });
     }
 
@@ -467,11 +465,10 @@ services::Status computeTypeDisp(HostAppIface * pHostApp, const NumericTable * x
         const dtrees::internal::IndexedFeatures::IndexType * fi = indexedFeatures.data(0);
 
         const size_t nPerBlock = nRows / nThreads;
-        const size_t nSurplus = nRows % nThreads;
-        daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
-        {
+        const size_t nSurplus  = nRows % nThreads;
+        daal::threader_for(nThreads, nThreads, [&](size_t iBlock) {
             size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-            size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+            size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
             for (size_t i = start; i < end; i++)
             {
                 PRAGMA_IVDEP

--- a/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
@@ -248,7 +248,8 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     val                       = -imp.g / val;
     const algorithmFPType inc = val * _par.shrinkage;
     const size_t nThreads     = numAvailableThreads();
-    if ( n < getThrOptBorder<cpu>(nThreads) || nThreads <= 1 )
+    const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
+    if ( nBlocks == 1 )
     {
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
@@ -259,9 +260,9 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     }
     else
     {
-        const size_t nPerBlock = n / nThreads;
-        const size_t nSurplus = n % nThreads;
-        daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
+        const size_t nPerBlock = n / nBlocks;
+        const size_t nSurplus = n % nBlocks;
+        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
         {
             size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);

--- a/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
@@ -249,27 +249,16 @@ double TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::computeLeafWeight
     const algorithmFPType inc = val * _par.shrinkage;
     const size_t nThreads     = numAvailableThreads();
     const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
-    if (nBlocks == 1)
-    {
+    const bool inParallel     = nBlocks > 1 ? true : false;
+    const size_t nPerBlock    = n / nBlocks;
+    const size_t nSurplus     = n % nBlocks;
+    LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
+        const size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+        const size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
-        for (size_t i = 0; i < n; ++i)
-        {
-            pf[idx[i] * this->_nTrees + iTree] += inc;
-        }
-    }
-    else
-    {
-        const size_t nPerBlock = n / nBlocks;
-        const size_t nSurplus  = n % nBlocks;
-        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
-            size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-            size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
-            PRAGMA_IVDEP
-            PRAGMA_VECTOR_ALWAYS
-            for (size_t i = start; i < end; i++) pf[idx[i] * this->_nTrees + iTree] += inc;
-        });
-    }
+        for (size_t i = start; i < end; i++) pf[idx[i] * this->_nTrees + iTree] += inc;
+    });
 
     return res + inc;
 }
@@ -454,9 +443,11 @@ services::Status computeTypeDisp(HostAppIface * pHostApp, const NumericTable * x
 
     if (inexactWithHistMethod)
     {
-        const size_t nThreads = threader_get_threads_number();
-        const size_t nRows    = x->getNumberOfRows();
-        const size_t nCols    = x->getNumberOfColumns();
+        size_t nThreads    = threader_get_threads_number();
+        size_t nRows       = x->getNumberOfRows();
+        size_t nCols       = x->getNumberOfColumns();
+        size_t nBlocks     = ((nThreads < nRows) ? nThreads : 1);
+        size_t sizeOfBlock = nRows / nBlocks + !!(nRows % nBlocks);
 
         newFIArr.resize(nRows * nCols);
         BinIndexType * newFI = newFIArr.get();
@@ -464,12 +455,11 @@ services::Status computeTypeDisp(HostAppIface * pHostApp, const NumericTable * x
 
         const dtrees::internal::IndexedFeatures::IndexType * fi = indexedFeatures.data(0);
 
-        const size_t nPerBlock = nRows / nThreads;
-        const size_t nSurplus  = nRows % nThreads;
-        daal::threader_for(nThreads, nThreads, [&](size_t iBlock) {
-            size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-            size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
-            for (size_t i = start; i < end; i++)
+        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
+            const size_t iStart = iBlock * sizeOfBlock;
+            const size_t iEnd   = (((iBlock + 1) * sizeOfBlock > nRows) ? nRows : iStart + sizeOfBlock);
+
+            for (size_t i = iStart; i < iEnd; ++i)
             {
                 PRAGMA_IVDEP
                 PRAGMA_VECTOR_ALWAYS

--- a/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
@@ -264,11 +264,11 @@ protected:
 
         const size_t nThreads = _ctx.numAvailableThreads();
         const size_t nBlocks  = getNBlocksForOpt<cpu>(nThreads, nSamples);
-        const bool inParallel = nBlocks > 1 ? true : false;
+        const bool inParallel = nBlocks > 1;
         daal::services::internal::TArray<algorithmFPType, cpu> gsArr(nBlocks);
         daal::services::internal::TArray<algorithmFPType, cpu> hsArr(nBlocks);
-        algorithmFPType * gs   = gsArr.get();
-        algorithmFPType * hs   = hsArr.get();
+        const algorithmFPType * gs   = gsArr.get();
+        const algorithmFPType * hs   = hsArr.get();
         const size_t nPerBlock = nSamples / nBlocks;
         const size_t nSurplus  = nSamples % nBlocks;
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {

--- a/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
@@ -264,9 +264,9 @@ protected:
 
         const size_t nThreads = _ctx.numAvailableThreads();
         const size_t nBlocks  = getNBlocksForOpt<cpu>(nThreads, nSamples);
-        if ( nBlocks == 1 )
+        if (nBlocks == 1)
         {
-            if ( aSampleToF )
+            if (aSampleToF)
             {
                 PRAGMA_VECTOR_ALWAYS
                 for (size_t i = 0; i < nSamples; ++i)
@@ -289,16 +289,15 @@ protected:
         {
             daal::services::internal::TArray<algorithmFPType, cpu> gsArr(nBlocks);
             daal::services::internal::TArray<algorithmFPType, cpu> hsArr(nBlocks);
-            algorithmFPType * gs = gsArr.get();
-            algorithmFPType * hs = hsArr.get();
+            algorithmFPType * gs   = gsArr.get();
+            algorithmFPType * hs   = hsArr.get();
             const size_t nPerBlock = nSamples / nBlocks;
-            const size_t nSurplus = nSamples % nBlocks;
-            if ( aSampleToF )
+            const size_t nSurplus  = nSamples % nBlocks;
+            if (aSampleToF)
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     algorithmFPType localG, localH;
                     localG = localH = 0;
                     PRAGMA_VECTOR_ALWAYS
@@ -313,10 +312,9 @@ protected:
             }
             else
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     algorithmFPType localG, localH;
                     localG = localH = 0;
                     PRAGMA_VECTOR_ALWAYS

--- a/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
@@ -267,10 +267,10 @@ protected:
         const bool inParallel = nBlocks > 1;
         daal::services::internal::TArray<algorithmFPType, cpu> gsArr(nBlocks);
         daal::services::internal::TArray<algorithmFPType, cpu> hsArr(nBlocks);
-        const algorithmFPType * gs   = gsArr.get();
-        const algorithmFPType * hs   = hsArr.get();
-        const size_t nPerBlock = nSamples / nBlocks;
-        const size_t nSurplus  = nSamples % nBlocks;
+        algorithmFPType * const gs = gsArr.get();
+        algorithmFPType * const hs = hsArr.get();
+        const size_t nPerBlock     = nSamples / nBlocks;
+        const size_t nSurplus      = nSamples % nBlocks;
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             const size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);

--- a/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_tree_builder.i
@@ -286,13 +286,12 @@ protected:
         }
         else
         {
-            algorithmFPType gs[nThreads];
-            algorithmFPType hs[nThreads];
-            for (size_t i = 0; i < nThreads; i++)
-            {
-                gs[i] = 0;
-                hs[i] = 0;
-            }
+            daal::services::internal::TArray<algorithmFPType, cpu> gsArr(nThreads);
+            daal::services::internal::TArray<algorithmFPType, cpu> hsArr(nThreads);
+            algorithmFPType * gs = gsArr.get();
+            algorithmFPType * hs = hsArr.get();
+            daal::services::internal::service_memset<algorithmFPType, cpu>(gs, 0, nThreads);
+            daal::services::internal::service_memset<algorithmFPType, cpu>(hs, 0, nThreads);
             const size_t nPerBlock = nSamples / nThreads;
             const size_t nSurplus = nSamples % nThreads;
             if ( aSampleToF )

--- a/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
@@ -134,7 +134,7 @@ protected:
         const size_t nPerBlock    = n / nBlocks;
         const size_t nSurplus     = n % nBlocks;
         services::internal::TArray<algorithmFPType, cpu> pvalsArr(nBlocks);
-        const algorithmFPType * pvals = pvalsArr.get();
+        algorithmFPType * const pvals = pvalsArr.get();
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
             const size_t start    = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             const size_t end      = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);

--- a/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
@@ -59,7 +59,7 @@ public:
         const size_t nBlocks   = getNBlocksForOpt<cpu>(nThreads, n);
         const size_t nPerBlock = n / nBlocks;
         const size_t nSurplus  = n % nBlocks;
-        const bool inParallel  = nBlocks > 1 ? true : false;
+        const bool inParallel  = nBlocks > 1;
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             const size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
@@ -130,11 +130,11 @@ protected:
         val                       = algorithmFPType(0);
         const size_t nThreads     = super::numAvailableThreads();
         const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
-        const bool inParallel     = nBlocks > 1 ? true : false;
+        const bool inParallel     = nBlocks > 1;
         const size_t nPerBlock    = n / nBlocks;
         const size_t nSurplus     = n % nBlocks;
         services::internal::TArray<algorithmFPType, cpu> pvalsArr(nBlocks);
-        algorithmFPType * pvals = pvalsArr.get();
+        const algorithmFPType * pvals = pvalsArr.get();
         LoopHelper<cpu>::run(inParallel, nBlocks, [&](size_t iBlock) {
             const size_t start    = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
             const size_t end      = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);

--- a/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
@@ -167,8 +167,9 @@ protected:
         {
             const size_t nPerBlock = n / nThreads;
             const size_t nSurplus = n % nThreads;
-            algorithmFPType pvals[nThreads];
-            for(size_t i = 0; i < nThreads; i++) pvals[i] = 0;
+            services::internal::TArray<algorithmFPType, cpu> pvalsArr(nThreads);
+            algorithmFPType * pvals = pvalsArr.get();
+            services::internal::service_memset<algorithmFPType, cpu>(pvals, 0, nThreads);
             daal::threader_for(nThreads, nThreads, [&](size_t iBlock)
             {
                 size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;

--- a/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/regression/gbt_regression_train_dense_default_impl.i
@@ -57,7 +57,7 @@ public:
     {
         const size_t nThreads = daal::threader_get_threads_number();
         const size_t nBlocks  = getNBlocksForOpt<cpu>(nThreads, n);
-        if ( nBlocks == 1 )
+        if (nBlocks == 1)
         {
             if (sampleInd)
             {
@@ -83,13 +83,12 @@ public:
         else
         {
             const size_t nPerBlock = n / nBlocks;
-            const size_t nSurplus = n % nBlocks;
+            const size_t nSurplus  = n % nBlocks;
             if (sampleInd)
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
@@ -101,10 +100,9 @@ public:
             }
             else
             {
-                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-                {
+                daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
                     size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                    size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+                    size_t end   = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
                     for (size_t i = start; i < end; i++)
@@ -161,23 +159,22 @@ protected:
         val                       = algorithmFPType(0);
         const size_t nThreads     = super::numAvailableThreads();
         const size_t nBlocks      = getNBlocksForOpt<cpu>(nThreads, n);
-        if ( nBlocks == 1 )
+        if (nBlocks == 1)
         {
-            for (size_t i = 0; i < n; ++i) val += div*py[i];
+            for (size_t i = 0; i < n; ++i) val += div * py[i];
         }
         else
         {
             const size_t nPerBlock = n / nBlocks;
-            const size_t nSurplus = n % nBlocks;
+            const size_t nSurplus  = n % nBlocks;
             services::internal::TArray<algorithmFPType, cpu> pvalsArr(nBlocks);
             algorithmFPType * pvals = pvalsArr.get();
-            daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock)
-            {
-                size_t start = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
-                size_t end = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
+            daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
+                size_t start          = iBlock + 1 > nSurplus ? nPerBlock * iBlock + nSurplus : (nPerBlock + 1) * iBlock;
+                size_t end            = iBlock + 1 > nSurplus ? start + nPerBlock : start + (nPerBlock + 1);
                 algorithmFPType lpval = 0;
                 PRAGMA_ICC_NO16(omp simd reduction(+ : lpval))
-                for (size_t i = start; i < end; i++) lpval += div*py[i];
+                for (size_t i = start; i < end; i++) lpval += div * py[i];
                 pvals[iBlock] = lpval;
             });
             for (size_t i = 0; i < nBlocks; i++) val += pvals[i];


### PR DESCRIPTION
# Description
GBT performance optimizations for specific dimensions. Change of GBT initialization behavior on small number of rows.

Changes proposed in this pull request:
- Threading in Squared Loss and Log Loss, TreeBuilder of GBT.
- Change of GBT initialization to avoid early switch to factually exact split mode if maxBins*minBinSize < nRows.