### PR TITLE
helper scripts fixed

### DIFF
--- a/scripts/tbb.bat
+++ b/scripts/tbb.bat
@@ -33,13 +33,14 @@ if /i "%1"=="" (
 	set DST=%1\..\externals\tbb
 )
 
-if not exist %DST% mkdir %DST%
+if not exist %DST% powershell.exe -command "New-Item -Path \"%DST%\" -ItemType Directory"
+if not exist %DST%\win powershell.exe -command "New-Item -Path \"%DST%\win\" -ItemType Directory"
 
-if not exist "%DST%\%TBBPACKAGE%\license.txt" (
+if not exist "%DST%\win\bin" (
 	powershell.exe -command "if (Get-Command Invoke-WebRequest -errorAction SilentlyContinue){[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest %TBBURL% -OutFile %DST%\%TBBPACKAGE%.zip} else {exit 1}" && goto Unpack goto Error_load
 
 :Unpack
-	powershell.exe -command "if (Get-Command Add-Type -errorAction SilentlyContinue) {Add-Type -Assembly \"System.IO.Compression.FileSystem\"; try { [IO.Compression.zipfile]::ExtractToDirectory(\"%DST%\%TBBPACKAGE%.zip\", \"%DST%\") ; Copy-Item \"%DST%\%TBBVERSION%\*\" -Destination \"%DST%\" -Recurse }catch{$_.exception ; exit 1}} else {exit 1}" && goto Exit || goto Error_unpack
+	powershell.exe -command "if (Get-Command Add-Type -errorAction SilentlyContinue) {Add-Type -Assembly \"System.IO.Compression.FileSystem\"; try { [IO.Compression.zipfile]::ExtractToDirectory(\"%DST%\%TBBPACKAGE%.zip\", \"%DST%\") ; Copy-Item \"%DST%\%TBBVERSION%\*\" -Destination \"%DST%\win\" -Recurse }catch{$_.exception ; exit 1}} else {exit 1}" && goto Exit || goto Error_unpack
 
 :Error_load
 	echo tbb.bat : Error: Failed to load %TBBURL% to %DST%, try to load it manually

--- a/scripts/tbb.sh
+++ b/scripts/tbb.sh
@@ -39,7 +39,7 @@ DST=`dirname $0`/../externals/tbb
 mkdir -p ${DST}/${OS}
 DST=`cd ${DST};pwd`
 
-if [ ! -e "${DST}/${TBB_PACKAGE}/license.txt" ]; then
+if [ ! -d "${DST}/${OS}/bin" ]; then
   if [ -x "$(command -v curl)" ]; then
     echo curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
     curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
@@ -58,7 +58,7 @@ if [ ! -e "${DST}/${TBB_PACKAGE}/license.txt" ]; then
   
   echo tar -xvf "${DST}/${TBB_PACKAGE}.tgz" -C ${DST}
   tar -C ${DST}/${OS} --strip-components=1 -xvf "${DST}/${TBB_PACKAGE}.tgz" ${TBB_VERSION}
-  echo "Downloaded and unpacked Intel(R) TBB to ${DST}"
+  echo "Downloaded and unpacked Intel(R) TBB to ${DST}/${OS}"
 else
-  echo "Intel(R) TBB is already installed in $DST"
+  echo "Intel(R) TBB is already installed in ${DST}/${OS}"
 fi


### PR DESCRIPTION
# Description
Fixes for helper scripts.

Changes proposed in this pull request:
- "tbb.{sh,bat} do tbb download even if tbb already downloaded." - Fixed.
- TBB location fixed on Windows to be able to build DAAL