### PR TITLE
2020 mnt -- third-party components were added to licence file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,125 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+  ===============================
+  
+   Bzip2
+   ------------------------------
+   Copyright (C) 1996-2005 Julian R Seward.
+   All rights reserved.
+
+   Bzip2 Licence
+
+    This program, "bzip2", the associated library "libbzip2", and all documentation, are copyright (C) 1996-2005 Julian R Seward. All rights reserved.
+      Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+      Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+      The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+      Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+      The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission.
+      THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   Zlib
+   ------------------------------
+   Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler.
+
+   The zlib/libpng License
+
+      This software is provided 'as-is', without any express or implied warranty. In no event will the authors be held liable for any damages arising from the use of this software.
+
+      Permission is granted to anyone to use this software for any purpose, including commercial applications, and to alter it and redistribute it freely, subject to the following restrictions:
+
+      1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software. If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
+
+      2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
+
+      3. This notice may not be removed or altered from any source distribution.
+
+   Intel® Integrated Performance Primitives (Intel® IPP) Library 
+   Intel® Math Kernel Library (Intel® MKL)
+   ------------------------------
+   Copyright 2019 Intel Corporation
+
+   Intel Simplified Software License (Version April 2018)
+
+      Use and Redistribution.  You may use and redistribute the software 
+     (the “Software”), without modification, provided the following conditions are met:
+
+     * Redistributions must reproduce the above copyright notice and the following 
+     terms of use in the Software and in the documentation and/or other materials 
+     provided with the distribution.
+
+     * Neither the name of Intel nor the names of its suppliers may be used to endorse 
+     or promote products derived from this Software without specific prior written permission.
+
+     * No reverse engineering, decompilation, or disassembly of this Software is permitted.
+
+     Limited patent license.  Intel grants you a world-wide, royalty-free, non-exclusive 
+     license under patents it now or hereafter owns or controls to make, have made, use, 
+     import, offer to sell and sell (“Utilize”) this Software, but solely to the extent 
+     that any such patent is necessary to Utilize the Software alone. The patent license 
+     shall not apply to any combinations which include this software.  
+     No hardware per se is licensed hereunder.
+
+     Third party and other Intel programs.  “Third Party Programs” are the files listed 
+     in the “third-party-programs.txt” text file that is included with the Software and 
+     may include Intel programs under separate license terms. Third Party Programs, 
+     even if included with the distribution of the Materials, are governed by separate 
+     license terms and those license terms solely govern your use of those programs. 
+
+     DISCLAIMER.  THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+     INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS 
+     FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT ARE DISCLAIMED. THIS SOFTWARE IS NOT 
+     INTENDED FOR USE IN SYSTEMS OR APPLICATIONS WHERE FAILURE OF THE SOFTWARE MAY CAUSE 
+     PERSONAL INJURY OR DEATH AND YOU AGREE THAT YOU ARE FULLY RESPONSIBLE FOR ANY CLAIMS, 
+     COSTS, DAMAGES, EXPENSES, AND ATTORNEYS’ FEES ARISING OUT OF ANY SUCH USE, EVEN IF ANY 
+     CLAIM ALLEGES THAT INTEL WAS NEGLIGENT REGARDING THE DESIGN OR MANUFACTURE OF THE MATERIALS.
+
+     LIMITATION OF LIABILITY. IN NO EVENT WILL INTEL BE LIABLE FOR ANY DIRECT, INDIRECT, 
+     INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+     PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+     INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+     LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. YOU AGREE TO INDEMNIFY 
+     AND HOLD INTEL HARMLESS AGAINST ANY CLAIMS AND EXPENSES RESULTING FROM YOUR USE OR 
+     UNAUTHORIZED USE OF THE SOFTWARE.
+
+     No support.  Intel may make changes to the Software, at any time without notice, and is not 
+     obligated to support, update or provide training for the Software.
+
+     Termination. Intel may terminate your right to use the Software in the event of your breach 
+     of this Agreement and you fail to cure the breach within a reasonable period of time.
+
+     Feedback.  Should you provide Intel with comments, modifications, corrections, enhancements 
+     or other input (“Feedback”) related to the Software Intel will be free to use, disclose, 
+     reproduce, license or otherwise distribute or exploit the Feedback in its sole discretion 
+     without any obligations or restrictions of any kind, including without limitation, 
+     intellectual property rights or licensing obligations.
+
+     Compliance with laws.  You agree to comply with all relevant laws and regulations governing 
+     your use, transfer, import or export (or prohibition thereof) of the Software.
+
+     Governing law.  All disputes will be governed by the laws of the United States of America and 
+     the State of Delaware without reference to conflict of law principles and subject to the 
+     exclusive jurisdiction of the state or federal courts sitting in the State of Delaware, and 
+     each party agrees that it submits to the personal jurisdiction and venue of those courts and 
+     waives any objections. The United Nations Convention on Contracts for the International 
+     Sale of Goods (1980) is specifically excluded and will not apply to the Software.
+
+     *Other names and brands may be claimed as the property of others.
+
+   Intel® Threading Building Blocks (Intel® TBB)
+   ------------------------------
+   Copyright 2019 Intel Corporation
+   Apache 2.0
+
+   prism: Copyright (c) 2012-2013 Lea Verou
+   ------------------------------
+   The MIT License (MIT)
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
# Description
The following components(their licences and copyrights) were added
- bzip2
- zlib
- Intel® Integrated Performance Primitives (Intel® IPP) Library
- Intel® Math Kernel Library (Intel® MKL)
- Intel® Threading Building Blocks (Intel® TBB)
- prism