### PR TITLE
MKL functions are enabled by default

### DIFF
--- a/examples/cpp_sycl/makefile_lnx
+++ b/examples/cpp_sycl/makefile_lnx
@@ -101,19 +101,19 @@ COPTS := -Wall -w -I./source/utils
 
 ifeq ($(compiler),clang)
     CC = clang++
-    COPTS += -fsycl -DONEAPI_DAAL_USE_MKL_GPU_FUNC
+    COPTS += -fsycl
     EXT_LIB += -foffload-static-lib=$(DAAL_PATH)/libdaal_sycl.a
 endif
 
 ifeq ($(compiler),intel)
     CC = icc
-    COPTS += $(if $(COVFILE), -m64)
+    COPTS += $(if $(COVFILE), -m64) -DONEAPI_DAAL_NO_MKL_GPU_FUNC
     EXT_LIB += -lComputeCpp
 endif
 
 ifeq ($(compiler),gnu)
     CC = g++
-    COPTS += -m64
+    COPTS += -m64 -DONEAPI_DAAL_NO_MKL_GPU_FUNC
     EXT_LIB += -lComputeCpp
 endif
 

--- a/examples/cpp_sycl/makefile_win
+++ b/examples/cpp_sycl/makefile_win
@@ -88,7 +88,7 @@ RES = $(example:+=.res)
 
 !IF ("$(compiler)"=="clang")
 CC=clang-cl
-COPTS=/clang:-fsycl /DONEAPI_DAAL_USE_MKL_GPU_FUNC /EHs
+COPTS=/clang:-fsycl /EHs
 OUT_OPTS=/Fe$(RES_DIR)
 RT_LIB=/link /ignore:4078 OpenCL.lib $(DAAL_PATH)\daal_sycl.lib
 CLEAN=

--- a/examples/cpp_sycl/vcproj/bf_knn_dense_batch/bf_knn_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/bf_knn_dense_batch/bf_knn_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/cor_dense_batch/cor_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/cor_dense_batch/cor_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/cor_dense_online/cor_dense_online.vcxproj
+++ b/examples/cpp_sycl/vcproj/cor_dense_online/cor_dense_online.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/datastructures_soa/datastructures_soa.vcxproj
+++ b/examples/cpp_sycl/vcproj/datastructures_soa/datastructures_soa.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/datastructures_usm/datastructures_usm.vcxproj
+++ b/examples/cpp_sycl/vcproj/datastructures_usm/datastructures_usm.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/gbt_reg_dense_batch/gbt_reg_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/gbt_reg_dense_batch/gbt_reg_dense_batch.vcxproj
@@ -45,53 +45,53 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.static.sequential|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.threaded|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.sequential|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.threaded|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.sequential|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.threaded|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.sequential|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>oneAPI Data Parallel C++ Compiler</PlatformToolset>
+    <PlatformToolset>Intel(R) oneAPI DPC++ Compiler</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -181,8 +181,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core.lib daal_thread.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.static.sequential|x64'">
@@ -197,8 +198,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core.lib daal_sequential.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.threaded|x64'">
@@ -213,8 +215,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core_dll.lib daal_thread.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.sequential|x64'">
@@ -229,8 +232,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core_dll.lib daal_sequential.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.threaded|x64'">
@@ -245,8 +249,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core.lib daal_thread.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.sequential|x64'">
@@ -261,8 +266,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core.lib daal_sequential.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.threaded|x64'">
@@ -277,8 +283,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core_dll.lib daal_thread.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_thread.lib;OpenCL.lib</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.sequential|x64'">
@@ -293,8 +300,9 @@
     </ClCompile>
     <Link>
       <TreatWarningAsError />
-      <AdditionalOptions> /link daal_core_dll.lib daal_sequential.lib /DEFAULTLIB:OpenCL.lib %(AdditionalOptions)</AdditionalOptions>
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
+      <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
+      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/examples/cpp_sycl/vcproj/gbt_reg_dense_batch/gbt_reg_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/gbt_reg_dense_batch/gbt_reg_dense_batch.vcxproj
@@ -183,7 +183,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.static.sequential|x64'">
@@ -200,7 +200,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.threaded|x64'">
@@ -217,7 +217,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.sequential|x64'">
@@ -234,7 +234,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.threaded|x64'">
@@ -251,7 +251,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_thread.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.sequential|x64'">
@@ -268,7 +268,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.threaded|x64'">
@@ -285,7 +285,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_thread.lib;OpenCL.lib</AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.sequential|x64'">
@@ -302,7 +302,7 @@
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
       <AdditionalDependencies>daal_sycl.lib;daal_core_dll.lib;daal_sequential.lib;OpenCL.lib </AdditionalDependencies>
-      <AdditionalOptions>/ignore:4078 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/examples/cpp_sycl/vcproj/kmeans_dense_batch/kmeans_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/kmeans_dense_batch/kmeans_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/kmeans_init_dense_batch/kmeans_init_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/kmeans_init_dense_batch/kmeans_init_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/lin_reg_norm_eq_dense_batch/lin_reg_norm_eq_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/lin_reg_norm_eq_dense_batch/lin_reg_norm_eq_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/log_reg_binary_dense_batch/log_reg_binary_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/log_reg_binary_dense_batch/log_reg_binary_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/log_reg_dense_batch/log_reg_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/log_reg_dense_batch/log_reg_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/low_order_moms_dense_batch/low_order_moms_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/low_order_moms_dense_batch/low_order_moms_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/low_order_moms_dense_online/low_order_moms_dense_online.vcxproj
+++ b/examples/cpp_sycl/vcproj/low_order_moms_dense_online/low_order_moms_dense_online.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/pca_cor_dense_batch/pca_cor_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/pca_cor_dense_batch/pca_cor_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/examples/cpp_sycl/vcproj/sgd_mini_log_loss_dense_batch/sgd_mini_log_loss_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/sgd_mini_log_loss_dense_batch/sgd_mini_log_loss_dense_batch.vcxproj
@@ -175,7 +175,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -192,7 +192,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -209,7 +209,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -226,7 +226,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -243,7 +243,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -260,7 +260,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -277,7 +277,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>
@@ -294,7 +294,7 @@
       <EnableSyclOffload>true</EnableSyclOffload>
       <SYCLWarningLevel>DisableAllWarnings</SYCLWarningLevel>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>ONEAPI_DAAL_USE_MKL_GPU_FUNC;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DebugInformationFormat>None</DebugInformationFormat>
       <SYCLOptimization>MaxSpeed</SYCLOptimization>
     </ClCompile>

--- a/include/oneapi/internal/math/blas_executor.h
+++ b/include/oneapi/internal/math/blas_executor.h
@@ -24,7 +24,7 @@
 //--
 */
 
-#ifndef ONEAPI_DAAL_NO_MKL_GPU_FUNC
+#if (!defined(ONEAPI_DAAL_NO_MKL_GPU_FUNC) && defined(__SYCL_COMPILER_VERSION))
     #include "mkl_blas.h"
 #endif
 

--- a/include/oneapi/internal/math/blas_executor.h
+++ b/include/oneapi/internal/math/blas_executor.h
@@ -24,13 +24,7 @@
 //--
 */
 
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-    #if !(defined(__clang__))
-        #undef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-    #endif
-#endif
-
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
+#ifndef ONEAPI_DAAL_NO_MKL_GPU_FUNC
     #include "mkl_blas.h"
 #endif
 
@@ -116,10 +110,10 @@ private:
             auto b_buffer_t = b_buffer.template get<T>();
             auto c_buffer_t = c_buffer.template get<T>();
 
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-            MKLGemm<T> functor(queue);
-#else
+#ifdef ONEAPI_DAAL_NO_MKL_GPU_FUNC
             ReferenceGemm<T> functor;
+#else
+            MKLGemm<T> functor(queue);
 #endif
 
             services::Status statusGemm =
@@ -192,13 +186,14 @@ private:
             const math::Transpose transInv = trans == math::Transpose::NoTrans ? math::Transpose::Trans : math::Transpose::NoTrans;
 
             services::Status statusSyrk;
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-            MKLSyrk<T> functor(queue);
-            statusSyrk = functor(upper_lower, transInv, k, n, (T)alpha, a_buffer_t, lda, offsetA, (T)beta, c_buffer_t, ldc, offsetC);
-#else
+
+#ifdef ONEAPI_DAAL_NO_MKL_GPU_FUNC
             ReferenceGemm<T> functor;
             statusSyrk =
                 functor(transInv, trans, k, k, n, (T)alpha, a_buffer_t, lda, offsetA, a_buffer_t, lda, offsetA, (T)beta, c_buffer_t, ldc, offsetC);
+#else
+            MKLSyrk<T> functor(queue);
+            statusSyrk = functor(upper_lower, transInv, k, n, (T)alpha, a_buffer_t, lda, offsetA, (T)beta, c_buffer_t, ldc, offsetC);
 #endif
 
             services::internal::tryAssignStatus(status, statusSyrk);

--- a/include/oneapi/internal/math/lapack_executor.h
+++ b/include/oneapi/internal/math/lapack_executor.h
@@ -24,7 +24,7 @@
 //--
 */
 
-#ifndef ONEAPI_DAAL_NO_MKL_GPU_FUNC
+#if (!defined(ONEAPI_DAAL_NO_MKL_GPU_FUNC) && defined(__SYCL_COMPILER_VERSION))
     #include "mkl_lapack.h"
 #endif
 

--- a/include/oneapi/internal/math/lapack_executor.h
+++ b/include/oneapi/internal/math/lapack_executor.h
@@ -24,13 +24,7 @@
 //--
 */
 
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-    #if !(defined(__clang__))
-        #undef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-    #endif
-#endif
-
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
+#ifndef ONEAPI_DAAL_NO_MKL_GPU_FUNC
     #include "mkl_lapack.h"
 #endif
 
@@ -81,10 +75,10 @@ private:
         {
             auto a_buffer_t = a_buffer.template get<T>();
 
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-            MKLPotrf<T> functor(queue);
-#else
+#ifdef ONEAPI_DAAL_NO_MKL_GPU_FUNC
             ReferencePotrf<T> functor;
+#else
+            MKLPotrf<T> functor(queue);
 #endif
 
             services::internal::tryAssignStatus(status, functor(uplo, n, a_buffer_t, lda));
@@ -130,10 +124,10 @@ private:
             auto a_buffer_t = a_buffer.template get<T>();
             auto b_buffer_t = b_buffer.template get<T>();
 
-#ifdef ONEAPI_DAAL_USE_MKL_GPU_FUNC
-            MKLPotrs<T> functor(queue);
-#else
+#ifdef ONEAPI_DAAL_NO_MKL_GPU_FUNC
             ReferencePotrs<T> functor;
+#else
+            MKLPotrs<T> functor(queue);
 #endif
 
             services::internal::tryAssignStatus(status, functor(uplo, n, ny, a_buffer_t, lda, b_buffer_t, ldb));


### PR DESCRIPTION
Macro **ONEAPI_DAAL_USE_MKL_GPU_FUNC** was replaced by **ONEAPI_DAAL_NO_MKL_GPU_FUNC** with inversing of benaviour. MKL functions are used by default now.

It is fix isuue #245