### PR TITLE
Add a note about minimal ClangFormat version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Public and private CIs are enabled for the repository. Your PR should pass all o
 ## Code Style
 
 Our repository contains [clang-format configurations](https://github.com/intel/daal/blob/master/.clang-format) that you should use on your code. 
+Minimal ClangFormat version: `9.0.0`.
 To do this, run:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ Public and private CIs are enabled for the repository. Your PR should pass all o
 
 ## Code Style
 
-Our repository contains [clang-format configurations](https://github.com/intel/daal/blob/master/.clang-format) that you should use on your code. 
-Minimal ClangFormat version: `9.0.0`.
-To do this, run:
+**Prerequisites:** ClangFormat `9.0.0` or later
+
+Our repository contains [clang-format configurations](https://github.com/intel/daal/blob/master/.clang-format) that you should use on your code. To do this, run:
 
 ```
 clang-format style=file <your file>


### PR DESCRIPTION
# Description
`withoutElse` option is available only since 9.0.0 clang format.

In other ways:

```
YAML:18:38: error: invalid boolean
AllowShortIfStatementsOnASingleLine: WithoutElse
```