### PR TITLE
Disable op= for Batch* classes with copy ctor

### DIFF
--- a/include/algorithms/association_rules/apriori.h
+++ b/include/algorithms/association_rules/apriori.h
@@ -155,6 +155,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/boosting/adaboost_predict.h
+++ b/include/algorithms/boosting/adaboost_predict.h
@@ -174,6 +174,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface1
 
@@ -301,6 +304,9 @@ protected:
         _in = &input;
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface2
 using interface2::Batch;

--- a/include/algorithms/boosting/adaboost_training_batch.h
+++ b/include/algorithms/boosting/adaboost_training_batch.h
@@ -174,6 +174,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -317,6 +320,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/boosting/boosting_predict.h
+++ b/include/algorithms/boosting/boosting_predict.h
@@ -103,6 +103,9 @@ public:
 
 protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/boosting/brownboost_predict.h
+++ b/include/algorithms/boosting/brownboost_predict.h
@@ -170,6 +170,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface1
 
@@ -291,6 +294,9 @@ protected:
         _in = &input;
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface2
 using interface2::Batch;

--- a/include/algorithms/boosting/brownboost_training_batch.h
+++ b/include/algorithms/boosting/brownboost_training_batch.h
@@ -173,6 +173,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -316,6 +319,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/boosting/logitboost_predict.h
+++ b/include/algorithms/boosting/logitboost_predict.h
@@ -181,6 +181,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -310,6 +313,9 @@ protected:
         _in = &input;
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/boosting/logitboost_training_batch.h
+++ b/include/algorithms/boosting/logitboost_training_batch.h
@@ -181,6 +181,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -328,6 +331,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/cholesky/cholesky.h
+++ b/include/algorithms/cholesky/cholesky.h
@@ -157,6 +157,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/classifier/binary_confusion_matrix_batch.h
+++ b/include/algorithms/classifier/binary_confusion_matrix_batch.h
@@ -168,6 +168,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/classifier/classifier_predict.h
+++ b/include/algorithms/classifier/classifier_predict.h
@@ -118,6 +118,9 @@ protected:
     void initialize() { _result.reset(new ResultType()); }
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
     interface1::ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -212,6 +215,9 @@ protected:
     void initialize() { _result.reset(new ResultType()); }
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/classifier/multiclass_confusion_matrix_batch.h
+++ b/include/algorithms/classifier/multiclass_confusion_matrix_batch.h
@@ -171,6 +171,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/dbscan/dbscan_batch.h
+++ b/include/algorithms/dbscan/dbscan_batch.h
@@ -174,6 +174,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/decision_forest/decision_forest_classification_predict.h
+++ b/include/algorithms/decision_forest/decision_forest_classification_predict.h
@@ -179,6 +179,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -302,6 +305,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/decision_forest/decision_forest_classification_training_batch.h
+++ b/include/algorithms/decision_forest/decision_forest_classification_training_batch.h
@@ -186,6 +186,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -335,6 +338,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/decision_forest/decision_forest_regression_predict.h
+++ b/include/algorithms/decision_forest/decision_forest_regression_predict.h
@@ -144,6 +144,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/decision_forest/decision_forest_regression_training_batch.h
+++ b/include/algorithms/decision_forest/decision_forest_regression_training_batch.h
@@ -168,6 +168,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/decision_tree/decision_tree_classification_predict.h
+++ b/include/algorithms/decision_tree/decision_tree_classification_predict.h
@@ -152,6 +152,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */
@@ -265,6 +268,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/decision_tree/decision_tree_classification_training_batch.h
+++ b/include/algorithms/decision_tree/decision_tree_classification_training_batch.h
@@ -171,6 +171,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */
@@ -304,6 +307,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/decision_tree/decision_tree_regression_predict.h
+++ b/include/algorithms/decision_tree/decision_tree_regression_predict.h
@@ -153,6 +153,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -269,6 +272,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/decision_tree/decision_tree_regression_training_batch.h
+++ b/include/algorithms/decision_tree/decision_tree_regression_training_batch.h
@@ -165,6 +165,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -292,6 +295,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/distance/correlation_distance.h
+++ b/include/algorithms/distance/correlation_distance.h
@@ -152,6 +152,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/distance/cosine_distance.h
+++ b/include/algorithms/distance/cosine_distance.h
@@ -152,6 +152,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/distributions/bernoulli/bernoulli.h
+++ b/include/algorithms/distributions/bernoulli/bernoulli.h
@@ -168,6 +168,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 
 } // namespace interface1

--- a/include/algorithms/distributions/normal/normal.h
+++ b/include/algorithms/distributions/normal/normal.h
@@ -169,6 +169,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 
 } // namespace interface1

--- a/include/algorithms/distributions/uniform/uniform.h
+++ b/include/algorithms/distributions/uniform/uniform.h
@@ -169,6 +169,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 
 } // namespace interface1

--- a/include/algorithms/em/em_gmm.h
+++ b/include/algorithms/em/em_gmm.h
@@ -148,6 +148,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/em/em_gmm_init_batch.h
+++ b/include/algorithms/em/em_gmm_init_batch.h
@@ -150,6 +150,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/engines/engine_family.h
+++ b/include/algorithms/engines/engine_family.h
@@ -90,6 +90,9 @@ protected:
     virtual size_t getMaxNumberOfStreamsImpl() const { return 0; }
 
     FamilyBatchBase(const FamilyBatchBase & other);
+
+private:
+    FamilyBatchBase& operator=(const FamilyBatchBase&);
 };
 typedef services::SharedPtr<FamilyBatchBase> FamilyEnginePtr;
 

--- a/include/algorithms/engines/mcg59/mcg59.h
+++ b/include/algorithms/engines/mcg59/mcg59.h
@@ -163,6 +163,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 typedef services::SharedPtr<Batch<> > mcg59Ptr;
 typedef services::SharedPtr<const Batch<> > mcg59ConstPtr;

--- a/include/algorithms/engines/mt19937/mt19937.h
+++ b/include/algorithms/engines/mt19937/mt19937.h
@@ -163,6 +163,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 typedef services::SharedPtr<Batch<> > mt19937Ptr;
 typedef services::SharedPtr<const Batch<> > mt19937ConstPtr;

--- a/include/algorithms/engines/mt2203/mt2203.h
+++ b/include/algorithms/engines/mt2203/mt2203.h
@@ -164,6 +164,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 typedef services::SharedPtr<Batch<> > mt2203Ptr;
 typedef services::SharedPtr<const Batch<> > mt2203ConstPtr;

--- a/include/algorithms/gradient_boosted_trees/gbt_classification_predict.h
+++ b/include/algorithms/gradient_boosted_trees/gbt_classification_predict.h
@@ -178,6 +178,9 @@ protected:
         _in = &input;
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -309,6 +312,9 @@ protected:
         _in = &input;
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/gradient_boosted_trees/gbt_classification_training_batch.h
+++ b/include/algorithms/gradient_boosted_trees/gbt_classification_training_batch.h
@@ -189,6 +189,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -336,6 +339,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/gradient_boosted_trees/gbt_regression_predict.h
+++ b/include/algorithms/gradient_boosted_trees/gbt_regression_predict.h
@@ -159,6 +159,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/gradient_boosted_trees/gbt_regression_training_batch.h
+++ b/include/algorithms/gradient_boosted_trees/gbt_regression_training_batch.h
@@ -178,6 +178,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/implicit_als/implicit_als_predict_ratings_batch.h
+++ b/include/algorithms/implicit_als/implicit_als_predict_ratings_batch.h
@@ -158,6 +158,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/implicit_als/implicit_als_training_batch.h
+++ b/include/algorithms/implicit_als/implicit_als_training_batch.h
@@ -149,6 +149,9 @@ protected:
         _par    = &parameter;
         _result = training::ResultPtr(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/implicit_als/implicit_als_training_init_batch.h
+++ b/include/algorithms/implicit_als/implicit_als_training_init_batch.h
@@ -152,6 +152,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/k_nearest_neighbors/bf_knn_classification_predict.h
+++ b/include/algorithms/k_nearest_neighbors/bf_knn_classification_predict.h
@@ -165,6 +165,9 @@ protected:
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _in = &input;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/k_nearest_neighbors/bf_knn_classification_training_batch.h
+++ b/include/algorithms/k_nearest_neighbors/bf_knn_classification_training_batch.h
@@ -186,6 +186,9 @@ protected:
         _result.reset(new ResultType());
         _in = &input;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict.h
+++ b/include/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict.h
@@ -150,6 +150,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */
@@ -263,6 +266,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/k_nearest_neighbors/kdtree_knn_classification_training_batch.h
+++ b/include/algorithms/k_nearest_neighbors/kdtree_knn_classification_training_batch.h
@@ -170,6 +170,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */
@@ -304,6 +307,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/kernel_function/kernel_function_linear.h
+++ b/include/algorithms/kernel_function/kernel_function_linear.h
@@ -153,6 +153,9 @@ protected:
         _res               = _result.get();
         return s;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/kernel_function/kernel_function_rbf.h
+++ b/include/algorithms/kernel_function/kernel_function_rbf.h
@@ -151,6 +151,9 @@ protected:
         _res               = _result.get();
         return s;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/kmeans/kmeans_batch.h
+++ b/include/algorithms/kmeans/kmeans_batch.h
@@ -166,6 +166,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/kmeans/kmeans_init_batch.h
+++ b/include/algorithms/kmeans/kmeans_init_batch.h
@@ -180,6 +180,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/lasso_regression/lasso_regression_predict.h
+++ b/include/algorithms/lasso_regression/lasso_regression_predict.h
@@ -122,6 +122,9 @@ protected:
         this->_par = NULL;
         this->_result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/linear_regression/linear_regression_group_of_betas_batch.h
+++ b/include/algorithms/linear_regression/linear_regression_group_of_betas_batch.h
@@ -181,6 +181,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/linear_regression/linear_regression_predict.h
+++ b/include/algorithms/linear_regression/linear_regression_predict.h
@@ -147,6 +147,9 @@ protected:
         this->_par = NULL;
         this->_result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/linear_regression/linear_regression_single_beta_batch.h
+++ b/include/algorithms/linear_regression/linear_regression_single_beta_batch.h
@@ -178,6 +178,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/linear_regression/linear_regression_training_batch.h
+++ b/include/algorithms/linear_regression/linear_regression_training_batch.h
@@ -163,6 +163,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/logistic_regression/logistic_regression_predict.h
+++ b/include/algorithms/logistic_regression/logistic_regression_predict.h
@@ -184,6 +184,9 @@ protected:
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -323,6 +326,9 @@ protected:
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, interface2::BatchContainer, algorithmFPType, method)(&_env);
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/logistic_regression/logistic_regression_training_batch.h
+++ b/include/algorithms/logistic_regression/logistic_regression_training_batch.h
@@ -187,6 +187,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -340,6 +343,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2
@@ -493,6 +499,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface3

--- a/include/algorithms/moments/low_order_moments_batch.h
+++ b/include/algorithms/moments/low_order_moments_batch.h
@@ -148,6 +148,9 @@ protected:
         _par = &parameter;
     }
     virtual BatchImpl * cloneImpl() const DAAL_C11_OVERRIDE = 0;
+
+private:
+    BatchImpl& operator=(const BatchImpl&);
 };
 
 /**
@@ -214,6 +217,9 @@ protected:
     }
 
     void initialize() { this->_ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env); }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/multi_class_classifier/multi_class_classifier_predict.h
+++ b/include/algorithms/multi_class_classifier/multi_class_classifier_predict.h
@@ -183,6 +183,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, pmethod, tmethod)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -327,6 +330,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, pmethod, tmethod)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/multi_class_classifier/multi_class_classifier_train.h
+++ b/include/algorithms/multi_class_classifier/multi_class_classifier_train.h
@@ -193,6 +193,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -344,6 +347,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/naive_bayes/multinomial_naive_bayes_predict.h
+++ b/include/algorithms/naive_bayes/multinomial_naive_bayes_predict.h
@@ -157,6 +157,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, interface1::BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -275,6 +278,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/naive_bayes/multinomial_naive_bayes_training_batch.h
+++ b/include/algorithms/naive_bayes/multinomial_naive_bayes_training_batch.h
@@ -179,6 +179,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -316,6 +319,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/normalization/minmax.h
+++ b/include/algorithms/normalization/minmax.h
@@ -162,6 +162,9 @@ protected:
     }
 
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/normalization/zscore.h
+++ b/include/algorithms/normalization/zscore.h
@@ -154,6 +154,9 @@ protected:
         _in     = &input;
     }
     virtual BatchImpl * cloneImpl() const DAAL_C11_OVERRIDE = 0;
+
+private:
+    BatchImpl& operator=(const BatchImpl&);
 };
 
 /**
@@ -236,6 +239,9 @@ protected:
     }
 
     void initialize() { Analysis<batch>::_ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env); }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/optimization_solver/adagrad/adagrad_batch.h
+++ b/include/algorithms/optimization_solver/adagrad/adagrad_batch.h
@@ -181,6 +181,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -319,6 +322,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_batch.h
+++ b/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_batch.h
@@ -180,6 +180,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/optimization_solver/iterative_solver/iterative_solver_batch.h
+++ b/include/algorithms/optimization_solver/iterative_solver/iterative_solver_batch.h
@@ -106,6 +106,9 @@ protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
 
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 typedef services::SharedPtr<Batch> BatchPtr;
@@ -180,6 +183,9 @@ protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
 
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 typedef services::SharedPtr<Batch> BatchPtr;

--- a/include/algorithms/optimization_solver/lbfgs/lbfgs_batch.h
+++ b/include/algorithms/optimization_solver/lbfgs/lbfgs_batch.h
@@ -182,6 +182,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -328,6 +331,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_batch.h
@@ -186,6 +186,9 @@ protected:
 
 public:
     InputType input; /*!< %Input data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -325,6 +328,9 @@ protected:
 
 public:
     InputType input; /*!< %Input data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/objective_function/logistic_loss_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/logistic_loss_batch.h
@@ -183,6 +183,9 @@ protected:
 
 public:
     InputType input; /*!< %Input data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -321,6 +324,9 @@ protected:
 
 public:
     InputType input; /*!< %Input data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/objective_function/mse_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/mse_batch.h
@@ -164,6 +164,9 @@ protected:
 public:
     InputType input;         /*!< %Input data structure */
     ParameterType parameter; /*!< %Parameter data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -295,6 +298,9 @@ protected:
 
 public:
     InputType input; /*!< %Input data structure */
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/objective_function/objective_function_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/objective_function_batch.h
@@ -113,6 +113,9 @@ protected:
 
 protected:
     objective_function::ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/optimization_solver/objective_function/precomputed_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/precomputed_batch.h
@@ -180,6 +180,9 @@ protected:
         _par                 = &parameter;
         _result              = objective_function::ResultPtr(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -323,6 +326,9 @@ protected:
         _par                 = &parameter;
         _result              = objective_function::ResultPtr(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/objective_function/sum_of_functions_batch.h
+++ b/include/algorithms/optimization_solver/objective_function/sum_of_functions_batch.h
@@ -108,6 +108,9 @@ protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
 
     void initialize() {}
+
+private:
+    Batch& operator=(const Batch&);
 };
 typedef services::SharedPtr<Batch> BatchPtr;
 
@@ -183,6 +186,9 @@ protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
 
     void initialize() {}
+
+private:
+    Batch& operator=(const Batch&);
 };
 typedef services::SharedPtr<Batch> BatchPtr;
 

--- a/include/algorithms/optimization_solver/saga/saga_batch.h
+++ b/include/algorithms/optimization_solver/saga/saga_batch.h
@@ -183,6 +183,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -329,6 +332,9 @@ protected:
         _in                  = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/optimization_solver/sgd/sgd_batch.h
+++ b/include/algorithms/optimization_solver/sgd/sgd_batch.h
@@ -187,6 +187,9 @@ protected:
         _in                  = &input;
         _result              = iterative_solver::interface1::ResultPtr(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -334,6 +337,9 @@ protected:
         _in                  = &input;
         _result              = iterative_solver::ResultPtr(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/outlier_detection/outlier_detection_bacon.h
+++ b/include/algorithms/outlier_detection/outlier_detection_bacon.h
@@ -166,6 +166,7 @@ public:
 
 private:
     ResultPtr _result;
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/outlier_detection/outlier_detection_multivariate.h
+++ b/include/algorithms/outlier_detection/outlier_detection_multivariate.h
@@ -163,6 +163,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/outlier_detection/outlier_detection_univariate.h
+++ b/include/algorithms/outlier_detection/outlier_detection_univariate.h
@@ -158,6 +158,8 @@ public:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/pca/pca_batch.h
+++ b/include/algorithms/pca/pca_batch.h
@@ -177,6 +177,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 
 /** @} */

--- a/include/algorithms/pca/pca_explained_variance_batch.h
+++ b/include/algorithms/pca/pca_explained_variance_batch.h
@@ -174,6 +174,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/pca/transform/pca_transform_batch.h
+++ b/include/algorithms/pca/transform/pca_transform_batch.h
@@ -160,6 +160,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/pivoted_qr/pivoted_qr_batch.h
+++ b/include/algorithms/pivoted_qr/pivoted_qr_batch.h
@@ -152,6 +152,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/qr/qr_batch.h
+++ b/include/algorithms/qr/qr_batch.h
@@ -152,6 +152,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/quantiles/quantiles_batch.h
+++ b/include/algorithms/quantiles/quantiles_batch.h
@@ -157,6 +157,9 @@ protected:
     }
 
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/ridge_regression/ridge_regression_predict.h
+++ b/include/algorithms/ridge_regression/ridge_regression_predict.h
@@ -148,6 +148,9 @@ protected:
         this->_par = NULL;
         this->_result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/ridge_regression/ridge_regression_training_batch.h
+++ b/include/algorithms/ridge_regression/ridge_regression_training_batch.h
@@ -160,6 +160,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/sorting/sorting_batch.h
+++ b/include/algorithms/sorting/sorting_batch.h
@@ -154,6 +154,9 @@ protected:
     }
 
     ResultPtr _result;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/stump/stump_classification_predict.h
+++ b/include/algorithms/stump/stump_classification_predict.h
@@ -178,6 +178,9 @@ protected:
         _ac = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _in = &input;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface1
 using interface1::BatchContainer;

--- a/include/algorithms/stump/stump_classification_training_batch.h
+++ b/include/algorithms/stump/stump_classification_training_batch.h
@@ -179,6 +179,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/stump/stump_predict.h
+++ b/include/algorithms/stump/stump_predict.h
@@ -165,6 +165,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = NULL;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface1
 using interface1::BatchContainer;

--- a/include/algorithms/stump/stump_regression_predict.h
+++ b/include/algorithms/stump/stump_regression_predict.h
@@ -183,6 +183,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 } // namespace interface1
 using interface1::BatchContainer;

--- a/include/algorithms/stump/stump_regression_training_batch.h
+++ b/include/algorithms/stump/stump_regression_training_batch.h
@@ -178,6 +178,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/stump/stump_training_batch.h
+++ b/include/algorithms/stump/stump_training_batch.h
@@ -170,6 +170,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/svd/svd_batch.h
+++ b/include/algorithms/svd/svd_batch.h
@@ -150,6 +150,8 @@ protected:
 
 private:
     ResultPtr _result;
+
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/svm/svm_predict.h
+++ b/include/algorithms/svm/svm_predict.h
@@ -157,6 +157,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -280,6 +283,9 @@ protected:
         _ac  = new __DAAL_ALGORITHM_CONTAINER(batch, BatchContainer, algorithmFPType, method)(&_env);
         _par = &parameter;
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/svm/svm_train.h
+++ b/include/algorithms/svm/svm_train.h
@@ -174,6 +174,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1
@@ -313,6 +316,9 @@ protected:
         _par = &parameter;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface2

--- a/include/algorithms/weak_learner/weak_learner_predict.h
+++ b/include/algorithms/weak_learner/weak_learner_predict.h
@@ -98,6 +98,9 @@ public:
 
 protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/weak_learner/weak_learner_training_batch.h
+++ b/include/algorithms/weak_learner/weak_learner_training_batch.h
@@ -95,6 +95,9 @@ public:
 
 protected:
     virtual Batch * cloneImpl() const DAAL_C11_OVERRIDE = 0;
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1


### PR DESCRIPTION
For Batch classes with non-trivial copy ctor we should use specific copy ctor or disable it;