### PR TITLE
Fix of sporadic adaboost multiclass samme java example [to releases branch]

### DIFF
--- a/algorithms/kernel/adaboost/adaboost_predict_dense_default_batch_fpt_cpu.cpp
+++ b/algorithms/kernel/adaboost/adaboost_predict_dense_default_batch_fpt_cpu.cpp
@@ -24,7 +24,6 @@
 #include "adaboost_predict_batch_container.h"
 #include "adaboost_predict_kernel.h"
 #include "adaboost_predict_impl.i"
-#include "boosting_predict_impl.i"
 
 namespace daal
 {

--- a/algorithms/kernel/adaboost/adaboost_predict_impl.i
+++ b/algorithms/kernel/adaboost/adaboost_predict_impl.i
@@ -276,7 +276,7 @@ services::Status AdaBoostPredictKernel<method, algorithmFPType, cpu>::processBlo
     const size_t nWeakLearners)
 {
     const algorithmFPType k_fptype = (algorithmFPType)k;
-    service_memset<algorithmFPType, cpu>(curClassScore, 0.0, nRowsInCurrentBlock);
+    service_memset_seq<algorithmFPType, cpu>(curClassScore, 0.0, nRowsInCurrentBlock);
     const size_t rWeakCols = (method == samme) ? 1 : nClasses;
     for (size_t m = 0; m < nWeakLearners; m++)
     {

--- a/algorithms/kernel/adaboost/adaboost_predict_kernel.h
+++ b/algorithms/kernel/adaboost/adaboost_predict_kernel.h
@@ -29,11 +29,9 @@
 #include "kernel.h"
 #include "numeric_table.h"
 #include "service_numeric_table.h"
-#include "boosting_predict_kernel.h"
 #include "service_environment.h"
 
 using namespace daal::data_management;
-using namespace daal::algorithms::boosting::prediction::internal;
 
 namespace daal
 {


### PR DESCRIPTION
Fixed:
- hidden nested threader_for that causes incorrect results
- removed unnecessary includes