### PR TITLE
Code cleanup

### DIFF
--- a/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -627,9 +627,6 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
         probPtr = probNT->getArray();
     }
 
-
-    const bool bUseTLS(_nClasses > s_cMaxClassesBufSize);
-    const size_t nCols(_data->getNumberOfColumns());
     daal::SafeStatus safeStat;
 
     const HomogenNumericTable<algorithmFPType> * hmgData = dynamic_cast<const HomogenNumericTable<algorithmFPType> *>(_data);
@@ -711,7 +708,6 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
 
     float * resPtr = nullptr;
     float * probPtr = nullptr;
-    ClassIndexType* valPtr = nullptr;
     HomogenNumericTable<float> * resNT  = dynamic_cast<HomogenNumericTable<float> *>(_res);
     HomogenNumericTable<float> * probNT = dynamic_cast<HomogenNumericTable<float> *>(_prob);
     const size_t nRows = _data->getNumberOfRows();
@@ -737,8 +733,6 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
         probPtr = probNT->getArray();
     }
 
-
-    const size_t nCols(_data->getNumberOfColumns());
     Status status;
 
     if(_prob != nullptr)
@@ -799,8 +793,6 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
         __m512i nOne   = _mm512_set1_epi32(-1);
         __m512i zero   = _mm512_set1_epi32(0);
         __m512 zero_ps = _mm512_set1_ps(0);
-        __m512 one_ps =  _mm512_set1_ps(1);
-        __m512 max_ps =  _mm512_set1_ps(-1);
         __m512i one    = _mm512_set1_epi32(1);
         __m512i idx =    _mm512_set_epi32(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
         __mmask16 ones_mask = 0xffff;

--- a/include/algorithms/algorithm_container_base_batch.h
+++ b/include/algorithms/algorithm_container_base_batch.h
@@ -180,6 +180,7 @@ public:
 protected:
     AlgorithmContainerImpl<batch> * _cntr;
 
+private:
     AlgorithmDispatchContainer(const AlgorithmDispatchContainer&);
     AlgorithmDispatchContainer& operator=(const AlgorithmDispatchContainer&);
 };

--- a/include/algorithms/algorithm_container_base_batch.h
+++ b/include/algorithms/algorithm_container_base_batch.h
@@ -179,10 +179,6 @@ public:
 
 protected:
     AlgorithmContainerImpl<batch> * _cntr;
-
-private:
-    AlgorithmDispatchContainer(const AlgorithmDispatchContainer&);
-    AlgorithmDispatchContainer& operator=(const AlgorithmDispatchContainer&);
 };
 
 /** @} */

--- a/include/algorithms/decision_forest/decision_forest_classification_training_types.h
+++ b/include/algorithms/decision_forest/decision_forest_classification_training_types.h
@@ -210,6 +210,8 @@ public:
 
 private:
     ResultImpl * _impl;
+
+    Result& operator=(const Result&);
 };
 typedef services::SharedPtr<Result> ResultPtr;
 

--- a/include/algorithms/decision_forest/decision_forest_regression_training_types.h
+++ b/include/algorithms/decision_forest/decision_forest_regression_training_types.h
@@ -250,6 +250,8 @@ public:
 
 private:
     ResultImpl * _impl;
+
+    Result& operator=(const Result&);
 };
 typedef services::SharedPtr<Result> ResultPtr;
 

--- a/include/algorithms/k_nearest_neighbors/bf_knn_classification_model.h
+++ b/include/algorithms/k_nearest_neighbors/bf_knn_classification_model.h
@@ -157,6 +157,9 @@ protected:
 
 private:
     ModelImpl *_impl;  /*!< Model implementation */
+
+    Model(const Model&);
+    Model& operator=(const Model&);
 };
 typedef services::SharedPtr<Model> ModelPtr;
 } // namespace interface1

--- a/include/algorithms/kernel_function/kernel_function.h
+++ b/include/algorithms/kernel_function/kernel_function.h
@@ -105,6 +105,9 @@ protected:
     void initialize() { _result = ResultPtr(new kernel_function::Result()); }
     virtual KernelIface * cloneImpl() const DAAL_C11_OVERRIDE = 0;
     ResultPtr _result;
+
+private:
+    KernelIface& operator=(const KernelIface&);
 };
 typedef services::SharedPtr<KernelIface> KernelIfacePtr;
 /** @} */

--- a/include/algorithms/lasso_regression/lasso_regression_training_batch.h
+++ b/include/algorithms/lasso_regression/lasso_regression_training_batch.h
@@ -175,6 +175,9 @@ protected:
         _in = &input;
         _result.reset(new ResultType());
     }
+
+private:
+    Batch& operator=(const Batch&);
 };
 /** @} */
 } // namespace interface1

--- a/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
+++ b/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
@@ -148,6 +148,8 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
                                                         function then no random sampling is performed, and all terms are
                                                         used to calculate the gradient. This parameter is ignored
                                                         if batchIndices is provided. */
+private:
+    Parameter& operator=(const Parameter&);
 };
 /* [interface1::Parameter source code] */
 
@@ -352,6 +354,8 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
                                                         function then no random sampling is performed, and all terms are
                                                         used to calculate the gradient. This parameter is ignored
                                                         if batchIndices is provided. */
+private:
+    Parameter& operator=(const Parameter&);
 };
 /* [Parameter source code] */
 

--- a/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
+++ b/include/algorithms/optimization_solver/iterative_solver/iterative_solver_types.h
@@ -148,8 +148,6 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
                                                         function then no random sampling is performed, and all terms are
                                                         used to calculate the gradient. This parameter is ignored
                                                         if batchIndices is provided. */
-private:
-    Parameter& operator=(const Parameter&);
 };
 /* [interface1::Parameter source code] */
 
@@ -354,8 +352,6 @@ struct DAAL_EXPORT Parameter : public daal::algorithms::Parameter
                                                         function then no random sampling is performed, and all terms are
                                                         used to calculate the gradient. This parameter is ignored
                                                         if batchIndices is provided. */
-private:
-    Parameter& operator=(const Parameter&);
 };
 /* [Parameter source code] */
 

--- a/include/data_management/data/data_archive.h
+++ b/include/data_management/data/data_archive.h
@@ -1231,6 +1231,10 @@ public:
 protected:
     DataArchiveIface * _arch;
     services::SharedPtr<services::ErrorCollection> _errors;
+
+private:
+    OutputDataArchive(const OutputDataArchive&);
+    OutputDataArchive& operator=(const OutputDataArchive&);
 };
 /** @} */
 

--- a/include/services/daal_atomic_int.h
+++ b/include/services/daal_atomic_int.h
@@ -90,6 +90,7 @@ protected:
 
 private:
     Atomic(const Atomic &);
+    Atomic& operator=(const Atomic &);
 };
 
 /** @} */

--- a/include/services/env_detect.h
+++ b/include/services/env_detect.h
@@ -183,6 +183,7 @@ public:
 private:
     Environment();
     Environment(const Environment & e);
+    Environment& operator=(const Environment &);
     ~Environment();
 
     void _cpu_detect(int);

--- a/include/services/error_handling.h
+++ b/include/services/error_handling.h
@@ -194,6 +194,8 @@ protected:
 private:
     ErrorID _id;
     ErrorDetail * _details;
+
+    Error& operator=(const Error &);
 };
 typedef SharedPtr<Error> ErrorPtr;
 


### PR DESCRIPTION
removed unused variables
disabled op=/cpyctors for classes w/ raw allocated pointers
fixed build(linkage) on msvc