### PR TITLE
fix helper scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -236,7 +236,7 @@ releasetbb.LIBS_Y := $(TBBDIR.soia)/$(plib)tbb.$(y) $(TBBDIR.soia)/$(plib)tbbmal
 
 RELEASEDIR.include.mklgpufpk := $(RELEASEDIR.include)/oneapi/internal/math
 
-MKLGPUFPKDIR:= $(if $(wildcard $(DIR)/externals/mklgpufpk/*),$(DIR)/externals/mklgpufpk,$(subst \,/,$(MKLGPUFPKROOT)))
+MKLGPUFPKDIR:= $(if $(wildcard $(DIR)/externals/mklgpufpk/$(_OS)/*),$(DIR)/externals/mklgpufpk/$(_OS),$(subst \,/,$(MKLGPUFPKROOT)))
 MKLGPUFPKDIR.include := $(MKLGPUFPKDIR)/include
 MKLGPUFPKDIR.libia   := $(MKLGPUFPKDIR)/lib/$(_IA)
 

--- a/scripts/mklfpk.bat
+++ b/scripts/mklfpk.bat
@@ -28,27 +28,32 @@ set MKLGPUPACKAGE=mklgpufpk_win_%MKLGPUVERSION%
 set MKLURL=%MKLURLROOT%%MKLPACKAGE%.zip
 set MKLGPUURL=%MKLURLROOT%%MKLGPUPACKAGE%.zip
 if /i "%1"=="" (
-	set CPUDST=%~dp0..\externals\mklfpk
-	set GPUDST=%~dp0..\externals\mklgpufpk
+	set CPUCOND=%~dp0..\externals\mklfpk
+	set GPUCOND=%~dp0..\externals\mklgpufpk
 ) else (
-	set CPUDST=%1\..\externals\mklfpk
-	set GPUDST=%1\..\externals\mklgpufpk
+	set CPUCOND=%1\..\externals\mklfpk
+	set GPUCOND=%1\..\externals\mklgpufpk
 )
 
-CALL :Download_FPK %CPUDST% , %MKLURL% , %MKLPACKAGE%
-CALL :Download_FPK %GPUDST% , %MKLGPUURL% , %MKLGPUPACKAGE%
+set CPUDST=%CPUCOND%
+set GPUDST="%GPUCOND%\win"
+
+CALL :Download_FPK %CPUDST% , %CPUCOND% , %MKLURL% , %MKLPACKAGE%
+CALL :Download_FPK %GPUDST% , %GPUCOND% , %MKLGPUURL% , %MKLGPUPACKAGE%
 
 exit /B 0
 
 :Download_FPK
 
 set DST=%~1
-set SRC=%~2
-set FILENAME=%~3
+set CONDITION=%~2
+set SRC=%~3
+set FILENAME=%~4
 
 if not exist %DST% mkdir %DST%
 
-if not exist "%DST%\license.txt" (
+
+if not exist "%CONDITION%\win\lib" (
 	powershell.exe -command "if (Get-Command Invoke-WebRequest -errorAction SilentlyContinue){[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest %SRC% -OutFile %DST%\%FILENAME%.zip} else {exit 1}" && goto Unpack || goto Error_load
 
 :Unpack

--- a/scripts/mklfpk.sh
+++ b/scripts/mklfpk.sh
@@ -41,12 +41,13 @@ function download_fpk()
 {
   SRC=$1
   DST=$2
-  FILENAME=$3
+  CONDITION=$3
+  FILENAME=$4
 
   mkdir -p ${DST}
   DST=`cd ${DST};pwd`
 
-  if [ ! -e "${DST}/license.txt" ]; then
+  if [ ! -e "${CONDITION}/${MKLFPK_OS}/lib/" ]; then
     if [ -x "$(command -v curl)" ]; then
       echo curl -L -o "${DST}/${FILENAME}" "${SRC}"
       curl -L -o "${DST}/${FILENAME}" "${SRC}"
@@ -86,10 +87,12 @@ MKLFPK_PACKAGE="mklfpk_${MKLFPK_OS}_${MKLFPK_VERSION}"
 MKLGPUFPK_PACKAGE="mklgpufpk_${MKLFPK_OS}_${MKLGPUFPK_VERSION}"
 MKLFPK_URL=${MKLFPK_URL_ROOT}${MKLFPK_PACKAGE}.tgz
 MKLGPUFPK_URL=${MKLFPK_URL_ROOT}${MKLGPUFPK_PACKAGE}.tgz
-CPUDST=`dirname $0`/../externals/mklfpk
-GPUDST=`dirname $0`/../externals/mklgpufpk
+CPUCOND=`dirname $0`/../externals/mklfpk
+GPUCOND=`dirname $0`/../externals/mklgpufpk
+CPUDST="${CPUCOND}"
+GPUDST="${GPUCOND}/${MKLFPK_OS}"
 
-download_fpk "${MKLFPK_URL}" "${CPUDST}" "${MKLFPK_PACKAGE}.tgz"
+download_fpk "${MKLFPK_URL}" "${CPUDST}" "${CPUCOND}" "${MKLFPK_PACKAGE}.tgz"
 if [ "${MKLFPK_OS}" != "mac" -a "${WITH_GPU}" == "true" ]; then
-  download_fpk "${MKLGPUFPK_URL}" "${GPUDST}" "${MKLGPUFPK_PACKAGE}.tgz"
+  download_fpk "${MKLGPUFPK_URL}" "${GPUDST}" "${GPUCOND}" "${MKLGPUFPK_PACKAGE}.tgz"
 fi


### PR DESCRIPTION
In case we try to install mklfpk at the same place for another system we receive message that mklfpk was already installed. To avoid that situation we may put each mklfpk in its own folder with name of system they are installed. 