### PR TITLE
Docs for DBSCAN converted

### DIFF
--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -81,6 +81,12 @@ For more information about algorithms implemented in |short_name|, refer to the 
    incomplete data via the em algorithm*. J. Royal Statist. Soc. Ser.
    B., 39, 1977.
 
+.. [Ester96]
+   Martin Ester, Hans-Peter Kriegel, Jörg Sander, and Xiaowei Xu.
+   A density-based algorithm for discovering clusters in large spatial databases with noise..
+   In Proceedings of the 2nd ACM International Conference on Knowledge Discovery and Data Mining (KDD).
+   226-231, 1996.
+
 .. [Fan05] 
    Rong-En Fan, Pai-Hsuen Chen, Chih-Jen Lin. *Working Set Selection
    Using Second Order Information for Training Support Vector

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,7 +76,8 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["opt-notice.rst", 'dev_guide/data-management/numeric-tables/*.rst', 'topics/*.rst']
+exclude_patterns = ["opt-notice.rst", 'dev_guide/data-management/numeric-tables/*.rst', 'topics/*.rst',
+                    'dev_guide/algorithms/dbscan/distributed-steps/*']
 
 extlinks = {'cpp_example': ('https://github.com/intel/daal/tree/master/examples/cpp/source/%s', ''),
 'java_example': ('https://github.com/intel/daal/tree/master/examples/java/com/intel/daal/examples/%s', ''),

--- a/docs/source/dev_guide/algorithms/dbscan/computation-batch.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-batch.rst
@@ -20,6 +20,7 @@ Batch Processing
 - `Algorithm Parameters`_
 - `Algorithm Input`_
 - `Algorithm Output`_
+- `Examples`_
 
 Algorithm Parameters
 ********************
@@ -47,7 +48,7 @@ The DBSCAN clustering algorithm has the following parameters:
      - The maximum distance between observations lying in the same neighborhood.
    * - ``minObservations``
      - Not applicable
-     - The number of observations in a neighborhood for an observation to be considered as a core one.
+     - The number of observations in a neighborhood for an observation to be considered as a :term:`core <core observation>` one.
    * - ``memorySavingMode``
      - ``false``
      - If flag is set to false, all neighborhoods will be computed and stored prior to clustering.
@@ -88,6 +89,7 @@ For more details, see :ref:`algorithms`.
        
          The input can be an object of any class derived from ``NumericTable``
          except ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``.
+         
          By default all weights are equal to :math:`1`.
 
 Algorithm Output
@@ -105,7 +107,8 @@ For more details, see :ref:`algorithms`.
      - Result
    * - ``assignments``
      - Pointer to the :math:`n \times 1` numeric table with assignments of cluster indices to observations in the input data.
-       Noise observations have the assignment equal to -1.
+       
+       :term:`Noise observations <noise observation>` have the assignment equal to :math:`-1`.
 
    * - ``nClusters``
      - Pointer to the :math:`1 \times 1` numeric table with the total number of clusters found by the algorithm.
@@ -123,6 +126,6 @@ For more details, see :ref:`algorithms`.
 Examples
 ********
 
-- C++: dbscan_dense_batch.cpp
-- Java*: DBSCANDenseBatch.java
-- Python*: dbscan_batch.py
+- :cpp_example:`C++ <dbscan/dbscan_dense_batch.cpp>`
+- :java_example:`Java* <dbscan/DBSCANDenseBatch.java>`
+- :daal4py_example:`Python* <dbscan_batch.py>`

--- a/docs/source/dev_guide/algorithms/dbscan/computation-batch.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-batch.rst
@@ -1,0 +1,128 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+Batch Processing
+================
+
+- `Algorithm Parameters`_
+- `Algorithm Input`_
+- `Algorithm Output`_
+
+Algorithm Parameters
+********************
+
+The DBSCAN clustering algorithm has the following parameters:
+
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
+
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
+
+       - ``defaultDense`` – uses brute-force for neighborhood computation
+
+   * - ``epsilon``
+     - Not applicable
+     - The maximum distance between observations lying in the same neighborhood.
+   * - ``minObservations``
+     - Not applicable
+     - The number of observations in a neighborhood for an observation to be considered as a core one.
+   * - ``memorySavingMode``
+     - ``false``
+     - If flag is set to false, all neighborhoods will be computed and stored prior to clustering.
+       It will require up to :math:`O(|\text{sum of sizes of all observations' neighborhoods}|)` of additional memory, 
+       which in worst case can be :math:`O(|\text{number of observations}|^2)`. However, in general, performance may be better.
+   * - ``resultsToCompute``
+     - :math:`0`
+     - The 64-bit integer flag that specifies which extra characteristics of the DBSCAN to compute.
+        
+       Provide one of the following values to request a single characteristic or
+       use bitwise OR to request a combination of the characteristics:
+
+       - ``computeCoreIndices`` for indices of core observations
+       - ``computeCoreObservations`` for core observations
+
+Algorithm Input
+***************
+
+The DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, see :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - data
+     - Pointer to the :math:`n \times p` numeric table with the data to be clustered.
+
+       .. note:: The input can be an object of any class derived from ``NumericTable``.
+
+   * - weights
+     - Optional input. Pointer to the :math:`n \times 1` numeric table with weights of observations.
+
+       .. note::
+       
+         The input can be an object of any class derived from ``NumericTable``
+         except ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``.
+         By default all weights are equal to :math:`1`.
+
+Algorithm Output
+****************
+
+The DBSCAN algorithms calculates the results described below.
+Pass the ``Result ID`` as a parameter to the methods that access the result of your algorithm.
+For more details, see :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Result ID
+     - Result
+   * - ``assignments``
+     - Pointer to the :math:`n \times 1` numeric table with assignments of cluster indices to observations in the input data.
+       Noise observations have the assignment equal to -1.
+
+   * - ``nClusters``
+     - Pointer to the :math:`1 \times 1` numeric table with the total number of clusters found by the algorithm.
+   * - ``coreIndices``
+     - Pointer to the numeric table with :math:`1` column and arbitrary number of rows, containing indices of core observations.
+   * - ``coreObservations``
+     - Pointer to the numeric table with :math:`p` columns and arbitrary number of rows, containing core observations.
+
+.. note::
+
+    By default, this result is an object of the ``HomogenNumericTable`` class,
+    but you can define the result as an object of any class derived from ``NumericTable``
+    except ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.
+
+Examples
+********
+
+- C++: dbscan_dense_batch.cpp
+- Java*: DBSCANDenseBatch.java
+- Python*: dbscan_batch.py

--- a/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
@@ -1,0 +1,108 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+Distributed Processing
+======================
+
+This mode assumes that the data set is split into ``nBlocks`` blocks across computation nodes.
+
+To compute DBSCAN algorithm in the distributed processing mode, 
+use the general schema described in Algorithms as follows:
+
+- `Step 1 - on Local Nodes`_
+- `Step 2 - on Local Nodes`_
+- `Step 3 - on Local Nodes`_
+- `Step 4 - on Local Nodes`_
+- `Step 5 - on Local Nodes`_
+- `Step 6 - on Local Nodes`_
+- `Step 7 - on Master Node`_
+- `Step 8 - on Local Nodes`_
+- `Step 9 - on Master Node`_
+- `Step 10 - on Local Nodes`_
+- `Step 11 - on Local Nodes`_
+- `Step 12 - on Local Nodes`_
+- `Step 13 - on Local Nodes`_
+
+Step 1 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-1.rst
+
+Step 2 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-2.rst
+
+Step 3 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-3.rst
+
+Step 4 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-4.rst
+
+Step 5 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-5.rst
+
+Step 6 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-6.rst
+
+Step 7 - on Master Node
+***********************
+
+.. include:: ./distributed-steps/step-7.rst
+
+Step 8 - on Local Nodes
+***********************
+
+.. include:: ./distributed-steps/step-8.rst
+    
+Step 9 - on Master Node
+***********************
+
+.. include:: ./distributed-steps/step-9.rst
+
+Step 10 - on Local Nodes
+************************
+
+.. include:: ./distributed-steps/step-10.rst
+
+Step 11 - on Local Nodes
+************************
+
+.. include:: ./distributed-steps/step-11.rst
+
+Step 12 - on Local Nodes
+************************
+
+.. include:: ./distributed-steps/step-12.rst
+
+Step 13 - on Local Nodes
+************************
+
+.. include:: ./distributed-steps/step-13.rst
+
+Examples
+********
+
+- C++: dbscan_dense_distr.cpp
+- Python*: dbscan_batch.py

--- a/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
@@ -20,7 +20,7 @@ Distributed Processing
 This mode assumes that the data set is split into ``nBlocks`` blocks across computation nodes.
 
 To compute DBSCAN algorithm in the distributed processing mode, 
-use the general schema described in Algorithms as follows:
+use the general schema described in :ref:`algorithms` as follows:
 
 - `Step 1 - on Local Nodes`_
 - `Step 2 - on Local Nodes`_
@@ -35,6 +35,7 @@ use the general schema described in Algorithms as follows:
 - `Step 11 - on Local Nodes`_
 - `Step 12 - on Local Nodes`_
 - `Step 13 - on Local Nodes`_
+- `Examples`_
 
 .. _dbscan_step_1:
 
@@ -130,5 +131,6 @@ Step 13 - on Local Nodes
 Examples
 ********
 
-- C++: dbscan_dense_distr.cpp
-- Python*: dbscan_batch.py
+- :cpp_example:`C++ <dbscan/dbscan_dense_distr.cpp>`
+- :java_example:`Java* <dbscan/DBSCANDenseDistr.java>`
+- :daal4py_example:`Python* <dbscan_spmd.py>`

--- a/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
@@ -36,65 +36,91 @@ use the general schema described in Algorithms as follows:
 - `Step 12 - on Local Nodes`_
 - `Step 13 - on Local Nodes`_
 
+.. _dbscan_step_1:
+
 Step 1 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-1.rst
+
+.. _dbscan_step_2:
 
 Step 2 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-2.rst
 
+.. _dbscan_step_3:
+
 Step 3 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-3.rst
+
+.. _dbscan_step_4:
 
 Step 4 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-4.rst
 
+.. _dbscan_step_5:
+
 Step 5 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-5.rst
+
+.. _dbscan_step_6:
 
 Step 6 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-6.rst
 
+.. _dbscan_step_7:
+
 Step 7 - on Master Node
 ***********************
 
 .. include:: ./distributed-steps/step-7.rst
 
+.. _dbscan_step_8:
+
 Step 8 - on Local Nodes
 ***********************
 
 .. include:: ./distributed-steps/step-8.rst
-    
+
+.. _dbscan_step_9:
+
 Step 9 - on Master Node
 ***********************
 
 .. include:: ./distributed-steps/step-9.rst
+
+.. _dbscan_step_10:
 
 Step 10 - on Local Nodes
 ************************
 
 .. include:: ./distributed-steps/step-10.rst
 
+.. _dbscan_step_11:
+
 Step 11 - on Local Nodes
 ************************
 
 .. include:: ./distributed-steps/step-11.rst
 
+.. _dbscan_step_12:
+
 Step 12 - on Local Nodes
 ************************
 
 .. include:: ./distributed-steps/step-12.rst
+
+.. _dbscan_step_13:
 
 Step 13 - on Local Nodes
 ************************

--- a/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/computation-distributed.rst
@@ -35,7 +35,8 @@ use the general schema described in :ref:`algorithms` as follows:
 - `Step 11 - on Local Nodes`_
 - `Step 12 - on Local Nodes`_
 - `Step 13 - on Local Nodes`_
-- `Examples`_
+
+You can find the links to `examples`_ at the end of this page.
 
 .. _dbscan_step_1:
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_data_collection.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_data_collection.rst
@@ -14,25 +14,8 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. note::
 
-Analysis
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+    By default, this result is an object of the ``DataCollection`` class. 
+    The numeric tables in collection can be an object of any class derived from ``NumericTable`
+    except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_data_collection.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_data_collection.rst
@@ -17,5 +17,5 @@
 .. note::
 
     By default, this result is an object of the ``DataCollection`` class. 
-    The numeric tables in collection can be an object of any class derived from ``NumericTable`
+    The numeric tables in the collection can be an object of any class derived from ``NumericTable`
     except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_numeric_table.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/default_result_numeric_table.rst
@@ -14,25 +14,8 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. note::
 
-Analysis
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+    By default, this result is an object of the ``HomogenNumericTable`` class, 
+    but you can define the result as an object of any class derived from ``NumericTable`` except for ``PackedTriangularMatrix``,
+    ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection.rst
@@ -14,25 +14,7 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. note::
 
-Analysis
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+    The input can be an object of any class derived from ``DataCollection``.
+    The numeric tables in collection can be an object of any class derived from ``NumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection.rst
@@ -17,4 +17,4 @@
 .. note::
 
     The input can be an object of any class derived from ``DataCollection``.
-    The numeric tables in collection can be an object of any class derived from ``NumericTable``.
+    The numeric tables in the collection can be an object of any class derived from ``NumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection_with_exceptions.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -14,25 +14,8 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. note::
 
-Analysis
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+    The input can be an object of any class derived from ``DataCollection``.
+    The numeric tables in collection can be an object of any class derived from ``NumericTable``
+    except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection_with_exceptions.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -17,5 +17,5 @@
 .. note::
 
     The input can be an object of any class derived from ``DataCollection``.
-    The numeric tables in collection can be an object of any class derived from ``NumericTable``
+    The numeric tables in the collection can be an object of any class derived from ``NumericTable``
     except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_numeric_table.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/input_numeric_table.rst
@@ -14,25 +14,7 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. note::
 
-Analysis
-========
-
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+    The input can be an object of any class derived from ``NumericTable``
+    except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters.rst
@@ -14,25 +14,18 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
 
-Analysis
-========
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
 
-.. toctree::
-   :maxdepth: 1
-
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+       - ``defaultDense`` – uses brute-force for neighborhood computation

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters_blocks.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters_blocks.rst
@@ -14,25 +14,25 @@
 .. * limitations under the License.
 .. *******************************************************************************/
 
-.. _analysis:
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
 
-Analysis
-========
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
 
-.. toctree::
-   :maxdepth: 1
+       - ``defaultDense`` – uses brute-force for neighborhood computation
 
-   algorithms/kmeans/k-means-clustering.rst
-   algorithms/dbscan/index.rst
-   algorithms/covariance/correlation-and-variance-covariance-matrices.rst
-   algorithms/pca/principal-component-analysis.rst
-   algorithms/svd/singular-value-decomposition.rst
-   algorithms/association_rules/association-rules.rst
-   algorithms/kernel_function/kernel-functions.rst
-   algorithms/em/expectation-maximization.rst
-
-.. toctree::
-   :maxdepth: 3
-   :caption: Optimization Solvers
-
-   algorithms/optimization-solvers/optimization-solvers.rst
+   * - ``blockIndex``
+     - Not applicable
+     - Unique identifier of block initially passed for computation on the local node.
+   * - ``nBlocks``
+     - Not applicable
+     - Number of blocks initially passed for computation on all nodes.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters_blocks_left_right.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/includes/parameters_blocks_left_right.rst
@@ -1,0 +1,38 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
+
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
+
+       - ``defaultDense`` – uses brute-force for neighborhood computation
+
+   * - ``leftBlocks``
+     - Not applicable
+     - Number of blocks that will process observations with value of selected split feature smaller than selected split value.
+   * - ``rightBlocks``
+     - Not applicable
+     - Number of blocks that will process observations with value of selected split feature greater than selected split value.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-1.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-1.rst
@@ -29,13 +29,14 @@ Pass the ``Input ID`` as a parameter to the methods that provide input for your 
      - Input
    * - ``step1Data``
      - Pointer to the :math:`n \times p` numeric table with the observations to be clustered.
-       The input can be an object of any class derived from NumericTable.
+       
+       .. note:: The input can be an object of any class derived from NumericTable.
 
 Algorithm Output
 ++++++++++++++++
 
 In this step, the DBSCAN algorithms calculates the partial results described below.
-Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-1.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-1.rst
@@ -1,0 +1,52 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below. 
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm. For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``step1Data``
+     - Pointer to the :math:`n \times p` numeric table with the observations to be clustered.
+       The input can be an object of any class derived from NumericTable.
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``partialOrder``
+     - Pointer to the :math:`n \times 2` numeric table containing information about observations: 
+       identifier of initial block and index in initial block. 
+       This information will be required to reconstruct initial blocks after transferring observations among nodes.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
@@ -1,0 +1,68 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``step10InputClusterStructure``
+     - Pointer to the numeric table with 4 columns and arbitrary number of rows containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+   * - ``step10ClusterOffset``
+     - Pointer to :math:`1 \times 1` numeric table containing the offset for cluster numeration on the local node computed on step 9.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``step10ClusterStructure``
+     - Pointer to the numeric table with 4 columns and arbitrary number of rows containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step10FinishedFlag``
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clusters numeration process is finished for current node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst       
+
+   * - ``step10Queries``
+     - Pointer to the collection of nBlocks numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
@@ -19,7 +19,7 @@ In this step, the DBSCAN algorithm has the following parameters:
 .. include:: distributed-steps/includes/parameters_blocks.rst
 
 In this step, the DBSCAN algorithm accepts the input described below.
-Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::
@@ -29,12 +29,13 @@ For more details, :ref:`algorithms`.
    * - Input ID
      - Input
    * - ``step10InputClusterStructure``
-     - Pointer to the numeric table with 4 columns and arbitrary number of rows containing information about current clustering state of observations processed on the local node.
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows containing
+       information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/input_numeric_table.rst
 
    * - ``step10ClusterOffset``
-     - Pointer to :math:`1 \times 1` numeric table containing the offset for cluster numeration on the local node computed on step 9.
+     - Pointer to :math:`1 \times 1` numeric table containing the offset for cluster numeration on the local node computed on :ref:`step 9 <dbscan_step_9>`.
 
        .. include:: distributed-steps/includes/input_numeric_table.rst
 
@@ -62,7 +63,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/default_result_numeric_table.rst       
 
    * - ``step10Queries``
-     - Pointer to the collection of nBlocks numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
+     - Pointer to the collection of ``nBlocks`` numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.
 
        .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-10.rst
@@ -53,7 +53,7 @@ For more details, :ref:`algorithms`.
    * - Partial Result ID
      - Result
    * - ``step10ClusterStructure``
-     - Pointer to the numeric table with 4 columns and arbitrary number of rows containing information about current clustering state of observations processed on the local node.
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows containing information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
@@ -63,7 +63,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/default_result_numeric_table.rst       
 
    * - ``step10Queries``
-     - Pointer to the collection of ``nBlocks`` numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`4` columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.
 
        .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
@@ -1,0 +1,71 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``step11InputClusterStructure``
+     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+       containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+   * - ``step11PartialQueries``
+     - Pointer to the collection of numeric tables with 4 columns and arbitrary number of rows
+       containing clusters numeration queries that should be processed on the local node collected from all nodes.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``step11ClusterStructure``
+     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+       containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step11FinishedFlag``
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clusters numeration process is finished for current node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step11Queries``
+     - Pointer to the collection of nBlocks numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
@@ -35,7 +35,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/input_numeric_table.rst
 
    * - ``step11PartialQueries``
-     - Pointer to the collection of numeric tables with 4 columns and arbitrary number of rows
+     - Pointer to the collection of numeric tables with :math:`4` columns and arbitrary number of rows
        containing clusters numeration queries that should be processed on the local node collected from all nodes.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -66,6 +66,7 @@ For more details, :ref:`algorithms`.
 
    * - ``step11Queries``
      - Pointer to the collection of ``nBlocks`` numeric tables with :math:`4` columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
-       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+       
+       Numeric tables in the collection are ordered by the identifiers of initial block of nodes.
 
        .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-11.rst
@@ -19,7 +19,7 @@ In this step, the DBSCAN algorithm has the following parameters:
 .. include:: distributed-steps/includes/parameters_blocks.rst
 
 In this step, the DBSCAN algorithm accepts the input described below.
-Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::
@@ -29,7 +29,7 @@ For more details, :ref:`algorithms`.
    * - Input ID
      - Input
    * - ``step11InputClusterStructure``
-     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
        containing information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/input_numeric_table.rst
@@ -44,7 +44,7 @@ Algorithm Output
 ++++++++++++++++
 
 In this step, the DBSCAN algorithms calculates the partial results described below.
-Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::
@@ -54,7 +54,7 @@ For more details, :ref:`algorithms`.
    * - Partial Result ID
      - Result
    * - ``step11ClusterStructure``
-     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
        containing information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
@@ -65,7 +65,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
    * - ``step11Queries``
-     - Pointer to the collection of nBlocks numeric tables with 4 columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`4` columns and arbitrary number of rows containing clusters numeration queries that should be processed on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.
 
        .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
@@ -20,7 +20,7 @@ In this step, the DBSCAN algorithm has the following parameters:
 .. include:: distributed-steps/includes/parameters_blocks.rst
 
 In this step, the DBSCAN algorithm accepts the input described below.
-Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::
@@ -30,13 +30,14 @@ For more details, :ref:`algorithms`.
    * - Input ID
      - Input
    * - ``step12InputClusterStructure``
-     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
        containing information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/input_numeric_table.rst
 
    * - ``step12PartialOrders``
-     - Pointer to the collection of :math:`n \times 2` numeric tables containing information about observations: identifier of initial block and index in initial block.
+     - Pointer to the collection of :math:`n \times 2` numeric tables containing information about observations:
+       identifier of initial block and index in initial block.
        This information will be required to reconstruct initial blocks after transferring observations among nodes.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -45,7 +46,7 @@ Algorithm Output
 ++++++++++++++++
 
 In this step, the DBSCAN algorithms calculates the partial results described below.
-Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::
@@ -55,7 +56,7 @@ For more details, :ref:`algorithms`.
    * - Partial Result ID
      - Result
    * - ``assignmentQueries``
-     - Pointer to the collection of nBlocks numeric tables with 2 columns and arbitrary number of rows
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`2` columns and arbitrary number of rows
        containing clusters assigning queries that should be processed on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
@@ -58,6 +58,7 @@ For more details, :ref:`algorithms`.
    * - ``assignmentQueries``
      - Pointer to the collection of ``nBlocks`` numeric tables with :math:`2` columns and arbitrary number of rows
        containing clusters assigning queries that should be processed on each node.
-       Numeric tables in collection ordered by the identifiers of initial block of nodes.
 
-       .. include:: distributed-steps/includes/default_result_data_collection.rst
+       Numeric tables in the collection are ordered by the identifiers of initial block of nodes.       
+
+.. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-12.rst
@@ -1,0 +1,62 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the Input ID as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``step12InputClusterStructure``
+     - Pointer to the numeric table with 4 columns and arbitrary number of rows
+       containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+   * - ``step12PartialOrders``
+     - Pointer to the collection of :math:`n \times 2` numeric tables containing information about observations: identifier of initial block and index in initial block.
+       This information will be required to reconstruct initial blocks after transferring observations among nodes.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``assignmentQueries``
+     - Pointer to the collection of nBlocks numeric tables with 2 columns and arbitrary number of rows
+       containing clusters assigning queries that should be processed on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-13.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-13.rst
@@ -29,7 +29,7 @@ For more details, :ref:`algorithms`.
    * - Input ID
      - Input
    * - ``partialAssignmentQueries``
-     - Pointer to the collection of numeric tables with 2 columns and arbitrary number of rows
+     - Pointer to the collection of numeric tables with :math:`2` columns and arbitrary number of rows
        containing clusters assigning queries that should be processed on the local node collected from all nodes.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -49,8 +49,8 @@ For more details, :ref:`algorithms`.
      - Result
    * - ``step13Assignments``
      - Pointer to the :math:`n \times 1` numeric table with assignments of cluster indices to observations
-       processed on step 1 on the local node.
-       Noise observations have the assignment equal to :math:`-1`.
+       processed on :ref:`step 1 <dbscan_step_1>` on the local node.
+       :term:`Noise observations <noise observation>` have the assignment equal to :math:`-1`.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
@@ -61,7 +61,7 @@ For more details, :ref:`algorithms`.
    * - Partial Result ID
      - Result
    * - ``step13AssignmentsQueries``
-     - Pointer to the numeric table with 2 columns and arbitrary number of rows
+     - Pointer to the numeric table with :math:`2` columns and arbitrary number of rows
        containing clusters assigning queries that should be processed on the local node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-13.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-13.rst
@@ -1,0 +1,67 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialAssignmentQueries``
+     - Pointer to the collection of numeric tables with 2 columns and arbitrary number of rows
+       containing clusters assigning queries that should be processed on the local node collected from all nodes.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the results and partial results described below.
+Pass the ``Result ID`` as a parameter to the methods that access the result and partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Result ID
+     - Result
+   * - ``step13Assignments``
+     - Pointer to the :math:`n \times 1` numeric table with assignments of cluster indices to observations
+       processed on step 1 on the local node.
+       Noise observations have the assignment equal to :math:`-1`.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``step13AssignmentsQueries``
+     - Pointer to the numeric table with 2 columns and arbitrary number of rows
+       containing clusters assigning queries that should be processed on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-2.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-2.rst
@@ -1,0 +1,53 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialData``
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing observations to be clustered.
+
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``boundingBox``
+     - Pointer to the :math:`2 \times p` numeric table containing bounding box of input observations:
+       first row contains minimum value of each feature, second row contains maximum value of each feature.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-3.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-3.rst
@@ -1,0 +1,59 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks_left_right.rst
+
+In this step, the DBSCAN algorithm accepts the input described below. Pass the Input ID as a parameter to the methods that provide input for your algorithm. For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialData``
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing observations to be clustered.
+    
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+   * - ``step3PartialBoundingBoxes``
+     - Pointer to the collection of the :math:`2 \times p` numeric tables containing bounding boxes computed on step 2 and collected from all nodes
+       participating in current iteration of geometric repartitioning process.
+       
+       .. note:: 
+         
+         The numeric tables in collection can be an object of any class
+         derived from ``NumericTable`` except for ``PackedTriangularMatrix``, ``PackedSymmetricMatrix``, and ``CSRNumericTable``.
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``split``
+     - Pointer to the :math:`1 \times 2` numeric table containing information about split for current iteration of geometric repartitioning.
+       
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-3.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-3.rst
@@ -18,7 +18,9 @@ In this step, the DBSCAN algorithm has the following parameters:
 
 .. include:: distributed-steps/includes/parameters_blocks_left_right.rst
 
-In this step, the DBSCAN algorithm accepts the input described below. Pass the Input ID as a parameter to the methods that provide input for your algorithm. For more details, :ref:`algorithms`.
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
 
 .. list-table::
    :widths: 10 60
@@ -32,7 +34,7 @@ In this step, the DBSCAN algorithm accepts the input described below. Pass the I
        .. include:: distributed-steps/includes/input_data_collection.rst
 
    * - ``step3PartialBoundingBoxes``
-     - Pointer to the collection of the :math:`2 \times p` numeric tables containing bounding boxes computed on step 2 and collected from all nodes
+     - Pointer to the collection of the :math:`2 \times p` numeric tables containing bounding boxes computed on :ref:`step 2 <dbscan_step_2>` and collected from all nodes
        participating in current iteration of geometric repartitioning process.
        
        .. note:: 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
@@ -1,0 +1,68 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks_left_right.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm. 
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialData``
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing observations to be clustered.
+
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+   * - ``step4PartialOrders``
+     - Pointer to the collection of numeric table with 2 columns and arbitrary number of rows containing information about observations:
+       identifier of initial block and index in initial block.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+   * - ``step4PartialSplits``
+     - Pointer to the collection of the :math:`1 \times 2` numeric table containing information about split computed on step 3 and collected from all nodes
+       participating in current iteration of geometric repartitioning process.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``partitionedData``
+     - Pointer to the collection of (``leftBlocks`` + ``rightBlocks``) numeric tables with :math:`p` columns and arbitrary number of rows
+       containing observations for processing on nodes participating in current iteration of geometric repartitioning.
+       
+       - First ``leftBlocks`` numeric tables in collection have the value of selected split feature smaller than selected split value.
+       - Next ``rightBlocks`` numeric tables in collection have the value of selected split feature larger than selected split value.
+       
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
@@ -34,7 +34,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/input_data_collection.rst
 
    * - ``step4PartialOrders``
-     - Pointer to the collection of numeric table with 2 columns and arbitrary number of rows containing information about observations:
+     - Pointer to the collection of numeric table with :math:`2` columns and arbitrary number of rows containing information about observations:
        identifier of initial block and index in initial block.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-4.rst
@@ -40,7 +40,8 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
 
    * - ``step4PartialSplits``
-     - Pointer to the collection of the :math:`1 \times 2` numeric table containing information about split computed on step 3 and collected from all nodes
+     - Pointer to the collection of the :math:`1 \times 2` numeric table containing information about split computed on
+       :ref:`step 3 <dbscan_step_3>` and collected from all nodes
        participating in current iteration of geometric repartitioning process.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
@@ -1,0 +1,89 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
+
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
+
+       - ``defaultDense`` – uses brute-force for neighborhood computation
+
+   * - ``blockIndex``
+     - Not applicable
+     - Unique identifier of block initially passed for computation on the local node.
+   * - ``nBlocks``
+     - Not applicable
+     - Number of blocks initially passed for computation on all nodes.
+   * - ``epsilon``
+     - Not applicable
+     - The maximum distance between observations lying in the same neighborhood.
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm. 
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialData``
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing observations to be clustered.
+
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+   * - ``step5PartialBoundingBoxes``
+     - Pointer to the collection of :math:`2 \times p` numeric table containing bounding boxes computed on step 2 and collected from all nodes.
+       Numeric tables in collection should be ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``partitionedHaloData``
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`p` columns and arbitrary number of rows containing observations
+       from current node that should be used as halo observations on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+   * - partitionedHaloDataIndices
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`1` column and arbitrary number of rows containing indices of observations
+       from current node that should be used as halo observations on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+.. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
@@ -79,11 +79,13 @@ For more details, :ref:`algorithms`.
    * - ``partitionedHaloData``
      - Pointer to the collection of ``nBlocks`` numeric tables with :math:`p` columns and arbitrary number of rows containing observations
        from current node that should be used as halo observations on each node.
-       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       Numeric tables in the collection are ordered by the identifiers of initial block of nodes.
 
    * - ``partitionedHaloDataIndices``
      - Pointer to the collection of ``nBlocks`` numeric tables with :math:`1` column and arbitrary number of rows containing indices of observations
        from current node that should be used as halo observations on each node.
-       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       Numeric tables in the collection are ordered by the identifiers of initial block of nodes.
 
 .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-5.rst
@@ -58,7 +58,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/input_data_collection.rst
 
    * - ``step5PartialBoundingBoxes``
-     - Pointer to the collection of :math:`2 \times p` numeric table containing bounding boxes computed on step 2 and collected from all nodes.
+     - Pointer to the collection of :math:`2 \times p` numeric table containing bounding boxes computed on :ref:`step 2 <dbscan_step_2>` and collected from all nodes.
        Numeric tables in collection should be ordered by the identifiers of initial block of nodes.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
@@ -81,7 +81,7 @@ For more details, :ref:`algorithms`.
        from current node that should be used as halo observations on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.
 
-   * - partitionedHaloDataIndices
+   * - ``partitionedHaloDataIndices``
      - Pointer to the collection of ``nBlocks`` numeric tables with :math:`1` column and arbitrary number of rows containing indices of observations
        from current node that should be used as halo observations on each node.
        Numeric tables in collection ordered by the identifiers of initial block of nodes.

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
@@ -43,7 +43,7 @@ In this step, the DBSCAN algorithm has the following parameters:
      - The maximum distance between observations lying in the same neighborhood.
    * - ``minObservations``
      - Not applicable
-     - The number of observations in a neighborhood for an observation to be considered as a core.
+     - The number of observations in a neighborhood for an observation to be considered as a :term:`core <core observation>`.
    * - ``memorySavingMode``
      - ``false``
      - If flag is set to false, all neighborhoods will be computed and stored prior to clustering.
@@ -66,21 +66,22 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/input_data_collection.rst
 
    * - ``haloData``
-     - Pointer to the collection of numeric tables with p columns and arbitrary number of rows, containing halo observations for current node computed on step 5.
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing halo observations
+       for current node computed on :ref:`step 5 <dbscan_step_5>`.
 
        .. include:: distributed-steps/includes/input_data_collection.rst
 
    * - ``haloDataIndices``
-     - Pointer to the collection of numeric tables with 1 column and arbitrary number of rows,
-       containing indices for halo observations for current node computed on step 5. 
+     - Pointer to the collection of numeric tables with :math:`1` column and arbitrary number of rows,
+       containing indices for halo observations for current node computed on :ref:`step 5 <dbscan_step_5>`. 
        Size of this collection should be equal to the size of collection for haloData Input ID.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
 
    * - ``haloDataBlocks``
-     - Pointer to the collection of 1 x 1 numeric tables containing identifiers of initial block for halo observations
-       for current node computed on step 5. 
-       Size of this collection should be equal to the size of collection for haloData Input ID.
+     - Pointer to the collection of :math:`1 \times 1` numeric tables containing identifiers of initial block for halo observations
+       for current node computed on :ref:`step 5 <dbscan_step_5>`. 
+       Size of this collection should be equal to the size of collection for ``haloData`` ``Input ID``.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
@@ -74,14 +74,16 @@ For more details, :ref:`algorithms`.
    * - ``haloDataIndices``
      - Pointer to the collection of numeric tables with :math:`1` column and arbitrary number of rows,
        containing indices for halo observations for current node computed on :ref:`step 5 <dbscan_step_5>`. 
-       Size of this collection should be equal to the size of collection for haloData Input ID.
+       
+       Size of this collection should be equal to the size of collection for ``haloData``'s ``Input ID``.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
 
    * - ``haloDataBlocks``
      - Pointer to the collection of :math:`1 \times 1` numeric tables containing identifiers of initial block for halo observations
        for current node computed on :ref:`step 5 <dbscan_step_5>`. 
-       Size of this collection should be equal to the size of collection for ``haloData`` ``Input ID``.
+       
+       Size of this collection should be equal to the size of collection for ``haloData``'s ``Input ID``.
 
        .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
 
@@ -89,7 +91,7 @@ Algorithm Output
 ++++++++++++++++
 
 In this step, the DBSCAN algorithms calculates the partial results described below.
-Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
 For more details, :ref:`algorithms`.
 
 .. list-table::

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-6.rst
@@ -1,0 +1,122 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. list-table::
+   :widths: 10 10 60
+   :header-rows: 1
+
+   * - Parameter
+     - Default Valude
+     - Description
+   * - ``algorithmFPType``
+     - ``float``
+     - The floating-point type that the algorithm uses for intermediate computations. Can be ``float`` or ``double``.
+   * - ``method``
+     - ``defaultDense``
+     - Available methods for computation of DBSCAN algorithm:
+
+       - ``defaultDense`` – uses brute-force for neighborhood computation
+
+   * - ``blockIndex``
+     - Not applicable
+     - Unique identifier of block initially passed for computation on the local node.
+   * - ``nBlocks``
+     - Not applicable
+     - Number of blocks initially passed for computation on all nodes.
+   * - ``epsilon``
+     - Not applicable
+     - The maximum distance between observations lying in the same neighborhood.
+   * - ``minObservations``
+     - Not applicable
+     - The number of observations in a neighborhood for an observation to be considered as a core.
+   * - ``memorySavingMode``
+     - ``false``
+     - If flag is set to false, all neighborhoods will be computed and stored prior to clustering.
+       It will require up to :math:`O(|\text{sum of sizes of neighborhoods}|)` of additional memory, 
+       which in worst case can be :math:`O(|\text{number of observations}|^2)`. However, in general, performance may be better.
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialData``
+     - Pointer to the collection of numeric tables with :math:`p` columns and arbitrary number of rows, containing observations to be clustered.
+
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+   * - ``haloData``
+     - Pointer to the collection of numeric tables with p columns and arbitrary number of rows, containing halo observations for current node computed on step 5.
+
+       .. include:: distributed-steps/includes/input_data_collection.rst
+
+   * - ``haloDataIndices``
+     - Pointer to the collection of numeric tables with 1 column and arbitrary number of rows,
+       containing indices for halo observations for current node computed on step 5. 
+       Size of this collection should be equal to the size of collection for haloData Input ID.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+   * - ``haloDataBlocks``
+     - Pointer to the collection of 1 x 1 numeric tables containing identifiers of initial block for halo observations
+       for current node computed on step 5. 
+       Size of this collection should be equal to the size of collection for haloData Input ID.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the Partial Result ID as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``step6ClusterStructure``
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
+       containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step6FinishedFlag``
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that
+       the clustering process is finished for current node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step6NClusters``
+     - Pointer to :math:`1 \times 1` numeric table containing the current number of clusters found on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - ``step6Queries``
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`3` columns and arbitrary number of rows
+       containing clustering queries that should be processed on each node.
+       Numeric tables in collection ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-7.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-7.rst
@@ -1,0 +1,54 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialFinishedFlags``
+     - Pointer to the collection of :math:`1 \times 1` numeric table containing the flag indicating
+       that the clustering process is finished collected from all nodes.
+       
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the results and partial results described below.
+Pass the ``Result ID`` as a parameter to the methods that access the result and partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``finishedFlag``
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating
+       that the clustering process is finished on all nodes.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
@@ -58,24 +58,24 @@ For more details, :ref:`algorithms`.
 
    * - Partial Result ID
      - Result
-   * - step8ClusterStructure
+   * - ``step8ClusterStructure``
      - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
        containing information about current clustering state of observations processed on the local node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst      
 
-   * - step8FinishedFlag
+   * - ``step8FinishedFlag``
      - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clustering process is finished for current node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
-   * - step8NClusters
+   * - ``step8NClusters``
      - Pointer to :math:`1 \times 1` numeric table containing the current number of clusters found on the local node.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
-   * - step8Queries
-     - Pointer to the collection of nBlocks numeric tables with 3 columns and arbitrary number of rows
+   * - ``step8Queries``
+     - Pointer to the collection of ``nBlocks`` numeric tables with 3 columns and arbitrary number of rows
        containing clustering queries that should be processed on each node. Numeric tables in collection
        ordered by the identifiers of initial block of nodes.
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
@@ -75,7 +75,7 @@ For more details, :ref:`algorithms`.
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 
    * - ``step8Queries``
-     - Pointer to the collection of ``nBlocks`` numeric tables with 3 columns and arbitrary number of rows
+     - Pointer to the collection of ``nBlocks`` numeric tables with :math:`3` columns and arbitrary number of rows
        containing clustering queries that should be processed on each node. Numeric tables in collection
        ordered by the identifiers of initial block of nodes.
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-8.rst
@@ -1,0 +1,82 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters_blocks.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``step8InputClusterStructure``
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows containing information about
+       current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+   * - ``step8InputNClusters``
+     - Pointer to :math:`1 \times 1` numeric tables containing the current number of clusters found on the local node.
+
+       .. include:: distributed-steps/includes/input_numeric_table.rst
+
+   * - ``step8PartialQueries``
+     - Pointer to the collection of numeric tables with :math:`3` columns and arbitrary number of rows containing
+       clustering queries that should be processed on the local node collected from all nodes.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the partial results described below.
+Pass the ``Partial Result ID`` as a parameter to the methods that access the partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - step8ClusterStructure
+     - Pointer to the numeric table with :math:`4` columns and arbitrary number of rows
+       containing information about current clustering state of observations processed on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst      
+
+   * - step8FinishedFlag
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clustering process is finished for current node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - step8NClusters
+     - Pointer to :math:`1 \times 1` numeric table containing the current number of clusters found on the local node.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+   * - step8Queries
+     - Pointer to the collection of nBlocks numeric tables with 3 columns and arbitrary number of rows
+       containing clustering queries that should be processed on each node. Numeric tables in collection
+       ordered by the identifiers of initial block of nodes.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-9.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-9.rst
@@ -47,7 +47,7 @@ For more details, :ref:`algorithms`.
    * - Result ID
      - Result
    * - ``step9NClusters``
-     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clustering process is finished on all nodes.
+     - Pointer to :math:`1 \times 1` numeric table containing the number of clusters found on all nodes.
 
        .. include:: distributed-steps/includes/default_result_numeric_table.rst
 

--- a/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-9.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/distributed-steps/step-9.rst
@@ -1,0 +1,64 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+In this step, the DBSCAN algorithm has the following parameters:
+
+.. include:: distributed-steps/includes/parameters.rst
+
+In this step, the DBSCAN algorithm accepts the input described below.
+Pass the ``Input ID`` as a parameter to the methods that provide input for your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Input ID
+     - Input
+   * - ``partialNClusters``
+     - Pointer to the collection of :math:`1 \times 1` numeric table containing the number of clusters found on each node.
+
+       .. include:: distributed-steps/includes/input_data_collection_with_exceptions.rst
+
+Algorithm Output
+++++++++++++++++
+
+In this step, the DBSCAN algorithms calculates the results and partial results described below.
+Pass the ``Result ID`` as a parameter to the methods that access the result and partial result of your algorithm.
+For more details, :ref:`algorithms`.
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Result ID
+     - Result
+   * - ``step9NClusters``
+     - Pointer to :math:`1 \times 1` numeric table containing the flag indicating that the clustering process is finished on all nodes.
+
+       .. include:: distributed-steps/includes/default_result_numeric_table.rst
+
+.. list-table::
+   :widths: 10 60
+   :header-rows: 1
+
+   * - Partial Result ID
+     - Result
+   * - ``clusterOffsets``
+     - Pointer to the collection of :math:`1 \times 1` numeric tables containing offsets for cluster numeration
+       for each node. Numeric tables with offsets are given in the same order as in the collection for ``partialNClusters`` ``Input ID``.
+
+       .. include:: distributed-steps/includes/default_result_data_collection.rst

--- a/docs/source/dev_guide/algorithms/dbscan/index.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/index.rst
@@ -1,0 +1,65 @@
+.. ******************************************************************************
+.. * Copyright 2014-2020 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+.. re-use for math equations:
+.. |x| replace:: :math:`x`
+.. |y| replace:: :math:`y`
+
+Density-Based Spatial Clustering of Applications with Noise
+===========================================================
+
+Density-based spatial clustering of applications with noise (DBSCAN) is a data clustering algorithm proposed in [Ester96]_. 
+It is a density-based clustering non-parametric algorithm: given a set of observations in some space,
+it groups together observations that are closely packed together (observations with many nearby neighbors),
+marking as outliers observations that lie alone in low-density regions (whose nearest neighbors are too far away).
+
+Details
+*******
+
+Given the set :math:`X = \{x_1 = (x_{11}, \ldots, x_{1p}), \ldots, x_n = (x_{n1}, \ldots, x_{np})\}` 
+of :math:`n` :math:`p`-dimensional feature vectors (further referred as observations),
+a positive floating-point number epsilon and a positive integer minObservations,
+the problem is to get clustering assignments for each input observation, based on the definitions below [Ester96]_:
+
+An observation |x| is called core observation if at least ``minObservations``
+input observations (including |x|) are within distance epsilon from observation |x|;
+
+An observation |y| is directly reachable from |x| if |y| is within distance epsilon from core observation |x|. 
+Observations are only said to be directly reachable from core observations.
+
+An observation |y| is reachable from observation |x| if there is a path :math:`x_1, \ldots, x_m` 
+with :math:`x_1 = x` and :math:`x_m = y`, where each :math:`x_{i+1}` is directly reachable from :math:`x_i`.
+This implies that all observations on the path must be core observations, with the possible exception of |y|.
+
+All observations not reachable from any other observation are noise observations.
+
+Two observations |x| and |y| is considered to be in the same cluster if there is a core observation :math:`z`, 
+that |x| and |y| are reachable from :math:`z`.
+
+Each cluster will get a unique identifier, an integer number from :math:`0` to (total number of clusters – :math:`1`).
+Assignment of each observation is an identifier of the cluster to which it belongs, 
+or :math:`-1` if the observation considered to be a noise observation.
+
+Computation
+***********
+
+The following computation modes are available:
+
+.. toctree::
+   :maxdepth: 1
+   
+   computation-batch.rst
+   computation-distributed.rst

--- a/docs/source/dev_guide/algorithms/dbscan/index.rst
+++ b/docs/source/dev_guide/algorithms/dbscan/index.rst
@@ -31,27 +31,34 @@ Details
 
 Given the set :math:`X = \{x_1 = (x_{11}, \ldots, x_{1p}), \ldots, x_n = (x_{n1}, \ldots, x_{np})\}` 
 of :math:`n` :math:`p`-dimensional feature vectors (further referred as observations),
-a positive floating-point number epsilon and a positive integer minObservations,
+a positive floating-point number ``epsilon`` and a positive integer ``minObservations``,
 the problem is to get clustering assignments for each input observation, based on the definitions below [Ester96]_:
 
-An observation |x| is called core observation if at least ``minObservations``
-input observations (including |x|) are within distance epsilon from observation |x|;
+.. glossary::
 
-An observation |y| is directly reachable from |x| if |y| is within distance epsilon from core observation |x|. 
-Observations are only said to be directly reachable from core observations.
+   core observation
+      An observation |x| is called core observation if at least ``minObservations``
+      input observations (including |x|) are within distance ``epsilon`` from observation |x|;
 
-An observation |y| is reachable from observation |x| if there is a path :math:`x_1, \ldots, x_m` 
-with :math:`x_1 = x` and :math:`x_m = y`, where each :math:`x_{i+1}` is directly reachable from :math:`x_i`.
-This implies that all observations on the path must be core observations, with the possible exception of |y|.
+   directly reachable
+      An observation |y| is directly reachable from |x| if |y| is within distance ``epsilon`` from :term:`core observation` |x|. 
+      Observations are only said to be directly reachable from :term:`core observations <core observation>`.
 
-All observations not reachable from any other observation are noise observations.
+   reachable
+      An observation |y| is reachable from an observation |x| if there is a path :math:`x_1, \ldots, x_m` 
+      with :math:`x_1 = x` and :math:`x_m = y`, where each :math:`x_{i+1}` is :term:`directly reachable` from :math:`x_i`.
+      This implies that all observations on the path must be :term:`core observations <core observation>`, with the possible exception of |y|.
 
-Two observations |x| and |y| is considered to be in the same cluster if there is a core observation :math:`z`, 
-that |x| and |y| are reachable from :math:`z`.
+   noise observation
+      Noise observations are observations that are :term:`not reachable <reachable>` from any other observation.
 
-Each cluster will get a unique identifier, an integer number from :math:`0` to (total number of clusters – :math:`1`).
-Assignment of each observation is an identifier of the cluster to which it belongs, 
-or :math:`-1` if the observation considered to be a noise observation.
+   cluster
+      Two observations |x| and |y| are considered to be in the same cluster if there is a :term:`core observation` :math:`z`, 
+      and |x| and |y| are both :term:`reachable` from :math:`z`.
+
+Each cluster gets a unique identifier, an integer number from :math:`0` to :math:`\text{total number of clusters } – 1`.
+Each observation is assigned an identifier of the :term:`cluster` it belongs to, 
+or :math:`-1` if the observation considered to be a :term:`noise observation`.
 
 Computation
 ***********


### PR DESCRIPTION
# Description

Converted documentation for DBSCAN (see [output](https://outoftardis.github.io/daal/dev_guide/algorithms/dbscan/index.html))