### PR TITLE
[rls/daal-2020-mnt] Add ability to train linear and ridge regression with n_observations < n_beta in QR method

### DIFF
--- a/algorithms/kernel/linear_model/linear_model_train_normeq_update_impl.i
+++ b/algorithms/kernel/linear_model/linear_model_train_normeq_update_impl.i
@@ -44,18 +44,16 @@ using namespace daal::internal;
 using namespace daal::services::internal;
 
 template <typename algorithmFPType, CpuType cpu>
-ThreadingTask<algorithmFPType, cpu>::ThreadingTask(size_t nBetasIntercept, size_t nResponses, Status &st) :
-    _nBetasIntercept(nBetasIntercept), _nResponses(nResponses)
+ThreadingTask<algorithmFPType, cpu>::ThreadingTask(size_t nBetasIntercept, size_t nResponses, Status & st)
+    : _nBetasIntercept(nBetasIntercept), _nResponses(nResponses)
 {
     _xtx = service_scalable_calloc<algorithmFPType, cpu>(nBetasIntercept * nBetasIntercept);
     _xty = service_scalable_calloc<algorithmFPType, cpu>(nBetasIntercept * nResponses);
-    if (!_xtx || !_xty)
-        st.add(ErrorMemoryAllocationFailed);
+    if (!_xtx || !_xty) st.add(ErrorMemoryAllocationFailed);
 }
 
 template <typename algorithmFPType, CpuType cpu>
-ThreadingTask<algorithmFPType, cpu> * ThreadingTask<algorithmFPType, cpu>::create(size_t nBetasIntercept,
-                                                                                  size_t nResponses)
+ThreadingTask<algorithmFPType, cpu> * ThreadingTask<algorithmFPType, cpu>::create(size_t nBetasIntercept, size_t nResponses)
 {
     Status st;
     ThreadingTask<algorithmFPType, cpu> * res = new ThreadingTask<algorithmFPType, cpu>(nBetasIntercept, nResponses, st);
@@ -68,8 +66,7 @@ ThreadingTask<algorithmFPType, cpu> * ThreadingTask<algorithmFPType, cpu>::creat
 }
 
 template <typename algorithmFPType, CpuType cpu>
-Status ThreadingTask<algorithmFPType, cpu>::update(DAAL_INT startRow, DAAL_INT nRows,
-                                                   const NumericTable &xTable, const NumericTable &yTable)
+Status ThreadingTask<algorithmFPType, cpu>::update(DAAL_INT startRow, DAAL_INT nRows, const NumericTable & xTable, const NumericTable & yTable)
 {
     DAAL_INT nFeatures(xTable.getNumberOfColumns());
 
@@ -93,13 +90,13 @@ Status ThreadingTask<algorithmFPType, cpu>::update(DAAL_INT startRow, DAAL_INT n
 
     if (nFeatures < _nBetasIntercept)
     {
-        algorithmFPType *xtxPtr = _xtx + nFeatures * _nBetasIntercept;
-        const algorithmFPType *xPtr = x;
+        algorithmFPType * xtxPtr     = _xtx + nFeatures * _nBetasIntercept;
+        const algorithmFPType * xPtr = x;
 
         for (DAAL_INT i = 0; i < nRows; i++, xPtr += nFeatures)
         {
-          PRAGMA_IVDEP
-          PRAGMA_VECTOR_ALWAYS
+            PRAGMA_IVDEP
+            PRAGMA_VECTOR_ALWAYS
             for (DAAL_INT j = 0; j < nFeatures; j++)
             {
                 xtxPtr[j] += xPtr[j];
@@ -114,11 +111,11 @@ Status ThreadingTask<algorithmFPType, cpu>::update(DAAL_INT startRow, DAAL_INT n
 
     if (nFeatures < _nBetasIntercept)
     {
-        const algorithmFPType *yPtr = y;
+        const algorithmFPType * yPtr = y;
         for (DAAL_INT i = 0; i < nRows; i++, yPtr += _nResponses)
         {
-          PRAGMA_IVDEP
-          PRAGMA_VECTOR_ALWAYS
+            PRAGMA_IVDEP
+            PRAGMA_VECTOR_ALWAYS
             for (DAAL_INT j = 0; j < _nResponses; j++)
             {
                 _xty[j * _nBetasIntercept + nFeatures] += yPtr[j];
@@ -129,17 +126,17 @@ Status ThreadingTask<algorithmFPType, cpu>::update(DAAL_INT startRow, DAAL_INT n
 }
 
 template <typename algorithmFPType, CpuType cpu>
-void ThreadingTask<algorithmFPType, cpu>::reduce(algorithmFPType *xtx, algorithmFPType *xty)
+void ThreadingTask<algorithmFPType, cpu>::reduce(algorithmFPType * xtx, algorithmFPType * xty)
 {
-  PRAGMA_IVDEP
-  PRAGMA_VECTOR_ALWAYS
+    PRAGMA_IVDEP
+    PRAGMA_VECTOR_ALWAYS
     for( size_t i = 0; i < (_nBetasIntercept * _nBetasIntercept); i++)
     {
         xtx[i] += _xtx[i];
     }
 
-  PRAGMA_IVDEP
-  PRAGMA_VECTOR_ALWAYS
+    PRAGMA_IVDEP
+    PRAGMA_VECTOR_ALWAYS
     for( size_t i = 0; i < (_nBetasIntercept * _nResponses); i++)
     {
         xty[i] += _xty[i];
@@ -154,26 +151,25 @@ ThreadingTask<algorithmFPType, cpu>::~ThreadingTask()
 }
 
 template <typename algorithmFPType, CpuType cpu>
-Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable &xTable, const NumericTable &yTable,
-                                                   NumericTable &xtxTable, NumericTable &xtyTable,
-                                                   bool initializeResult, bool interceptFlag)
+Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, const NumericTable & yTable, NumericTable & xtxTable,
+                                                   NumericTable & xtyTable, bool initializeResult, bool interceptFlag)
 {
-    DAAL_INT nRows     (xTable.getNumberOfRows());          /* observations */
-    DAAL_INT nResponses(yTable.getNumberOfColumns());       /* responses */
-    DAAL_INT nBetas    (xTable.getNumberOfColumns() + 1);   /* coefficients */
+    DAAL_INT nRows(xTable.getNumberOfRows());         /* observations */
+    DAAL_INT nResponses(yTable.getNumberOfColumns()); /* responses */
+    DAAL_INT nBetas(xTable.getNumberOfColumns() + 1); /* coefficients */
 
     size_t nBetasIntercept = (interceptFlag ? nBetas : (nBetas - 1));
 
     WriteRowsType xtxBlock(xtxTable, 0, nBetasIntercept);
     DAAL_CHECK_BLOCK_STATUS(xtxBlock);
-    algorithmFPType *xtx = xtxBlock.get();
+    algorithmFPType * xtx = xtxBlock.get();
 
     WriteRowsType xtyBlock(xtyTable, 0, nResponses);
     DAAL_CHECK_BLOCK_STATUS(xtyBlock);
-    algorithmFPType *xty = xtyBlock.get();
+    algorithmFPType * xty = xtyBlock.get();
 
     /* Initialize output arrays by zero in case of batch mode */
-    if(initializeResult)
+    if (initializeResult)
     {
         service_memset<algorithmFPType, cpu>(xtx, 0, nBetasIntercept * nBetasIntercept);
         service_memset<algorithmFPType, cpu>(xty, 0, nResponses * nBetasIntercept);
@@ -183,18 +179,17 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable &xTable, c
     size_t nRowsInBlock = 128;
 
     size_t nBlocks = nRows / nRowsInBlock;
-    if (nBlocks * nRowsInBlock < nRows) { nBlocks++; }
+    if (nBlocks * nRowsInBlock < nRows)
+    {
+        nBlocks++;
+    }
 
     /* Create TLS */
-    daal::tls<ThreadingTaskType *> tls( [ = ]() -> ThreadingTaskType*
-    {
-        return ThreadingTaskType::create(nBetasIntercept, nResponses);
-    } );
+    daal::tls<ThreadingTaskType *> tls([=]() -> ThreadingTaskType * { return ThreadingTaskType::create(nBetasIntercept, nResponses); });
 
     SafeStatus safeStat;
-    daal::threader_for( nBlocks, nBlocks, [ =, &tls, &xTable, &yTable, &safeStat ](int iBlock)
-    {
-        ThreadingTaskType *tlsLocal = tls.local();
+    daal::threader_for(nBlocks, nBlocks, [=, &tls, &xTable, &yTable, &safeStat](int iBlock) {
+        ThreadingTaskType * tlsLocal = tls.local();
 
         if (!tlsLocal)
         {
@@ -203,29 +198,29 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable &xTable, c
         }
 
         size_t startRow = iBlock * nRowsInBlock;
-        size_t endRow = startRow + nRowsInBlock;
-        if (endRow > nRows) { endRow = nRows; }
+        size_t endRow   = startRow + nRowsInBlock;
+        if (endRow > nRows)
+        {
+            endRow = nRows;
+        }
 
         Status localSt = tlsLocal->update(startRow, endRow - startRow, xTable, yTable);
         DAAL_CHECK_STATUS_THR(localSt);
-    } );
+    });
 
     Status st = safeStat.detach();
-    tls.reduce([ =, &st ](ThreadingTaskType *tlsLocal) -> void
-    {
-        if (!tlsLocal)
-            return;
-        if (st)
-            tlsLocal->reduce(xtx, xty);
+    tls.reduce([=, &st](ThreadingTaskType * tlsLocal) -> void {
+        if (!tlsLocal) return;
+        if (st) tlsLocal->reduce(xtx, xty);
         delete tlsLocal;
-    } );
+    });
 
     return st;
 }
 
-}
-}
-}
-}
-}
-}
+} // namespace internal
+} // namespace training
+} // namespace normal_equations
+} // namespace linear_model
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/linear_model/linear_model_train_qr_common_impl.i
+++ b/algorithms/kernel/linear_model/linear_model_train_qr_common_impl.i
@@ -42,7 +42,7 @@ using namespace daal::internal;
 using namespace daal::services::internal;
 
 template <typename algorithmFPType, CpuType cpu>
-Status CommonKernel<algorithmFPType, cpu>::computeWorkSize(DAAL_INT nRows, DAAL_INT nCols, DAAL_INT nResponses, DAAL_INT &lwork)
+Status CommonKernel<algorithmFPType, cpu>::computeWorkSize(DAAL_INT nRows, DAAL_INT nCols, DAAL_INT nResponses, DAAL_INT & lwork)
 {
     DAAL_INT info;
     algorithmFPType workLocal;
@@ -53,93 +53,118 @@ Status CommonKernel<algorithmFPType, cpu>::computeWorkSize(DAAL_INT nRows, DAAL_
 
     lwork1 = (DAAL_INT)workLocal;
 
-    char side = 'R';
-    char trans = 'T';
+    char side       = 'R';
+    char trans      = 'T';
     DAAL_INT lwork2 = -1;
-    Lapack<algorithmFPType, cpu>::xxormrq(&side, &trans, &nResponses, &nRows, &nCols, NULL,
-                                          &nCols, NULL, NULL, &nResponses, &workLocal,
-                                          &lwork2, &info);
+    Lapack<algorithmFPType, cpu>::xxormrq(&side, &trans, &nResponses, &nRows, &nCols, NULL, &nCols, NULL, NULL, &nResponses, &workLocal, &lwork2,
+                                          &info);
     DAAL_CHECK(info == 0, services::ErrorLinearRegressionInternal);
 
     lwork2 = (DAAL_INT)workLocal;
-    lwork = daal::services::internal::max<cpu, DAAL_INT>(lwork1, lwork2);
+    lwork  = daal::services::internal::max<cpu, DAAL_INT>(lwork1, lwork2);
 
     return Status();
 }
 
 template <typename algorithmFPType, CpuType cpu>
-Status CommonKernel<algorithmFPType, cpu>::computeQRForBlock(DAAL_INT p, DAAL_INT n,
-                                                             const algorithmFPType *x, DAAL_INT ny,
-                                                             const algorithmFPType *y, algorithmFPType *r,
-                                                             algorithmFPType *qty, algorithmFPType *tau,
-                                                             algorithmFPType *work, DAAL_INT lwork)
+Status CommonKernel<algorithmFPType, cpu>::computeQRForBlock(DAAL_INT p, DAAL_INT n, const algorithmFPType * x, DAAL_INT ny,
+                                                             const algorithmFPType * y, algorithmFPType * r, algorithmFPType * qty,
+                                                             algorithmFPType * tau, algorithmFPType * work, DAAL_INT lwork)
 {
     DAAL_INT info = 0;
 
     /* Calculate RQ decomposition of X */
-    Lapack<algorithmFPType, cpu>::xxgerqf(&p, &n, const_cast<algorithmFPType *>(x), &p, tau, work, &lwork,
-                                          &info);
+    Lapack<algorithmFPType, cpu>::xxgerqf(&p, &n, const_cast<algorithmFPType *>(x), &p, tau, work, &lwork, &info);
     DAAL_CHECK(info == 0, services::ErrorLinearRegressionInternal);
 
     /* Copy result into matrix R */
-    const DAAL_INT rOffset = (n - p) * p;
-    const algorithmFPType *xPtr = x + rOffset;
-    for (size_t i = 0; i < p; i++)
+    const DAAL_INT xOffset             = (n > p ? (n - p) * p : 0);
+    const DAAL_INT rOffset             = (n > p ? 0 : (p - n) * p);
+    const DAAL_INT nRowsInR            = daal::services::internal::min<cpu, DAAL_INT>(p, n);
+    const DAAL_INT jOffset             = (n > p ? 0 : p - n);
+    const algorithmFPType * const xPtr = x + xOffset;
+    algorithmFPType * const rPtr       = r + rOffset;
+
+    for (size_t i = 0; i < nRowsInR; ++i)
     {
-      PRAGMA_IVDEP
-      PRAGMA_VECTOR_ALWAYS
-        for (size_t j = 0; j <= i; j++)
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
+        for (size_t j = 0; j <= i + jOffset; ++j)
         {
-            r[i * p + j] = xPtr[i * p + j];
+            rPtr[i * p + j] = xPtr[i * p + j];
         }
     }
 
     /* Calculate Y*Q' */
-    char side = 'R';
+    char side  = 'R';
     char trans = 'T';
-    Lapack<algorithmFPType, cpu>::xxormrq(&side, &trans, &ny, &n, &p, const_cast<algorithmFPType *>(x), &p,
+    Lapack<algorithmFPType, cpu>::xxormrq(&side, &trans, &ny, &n, const_cast<DAAL_INT *>(&nRowsInR), const_cast<algorithmFPType *>(x + jOffset), &p,
                                           tau, const_cast<algorithmFPType *>(y), &ny, work, &lwork, &info);
     DAAL_CHECK(info == 0, services::ErrorLinearRegressionInternal);
 
+    if (p > n)
+    {
+        /* Complete a definition of a linear system if the number of observations
+         * less than the number of coefficients */
+        const algorithmFPType zero(0.0);
+        const algorithmFPType one(1.0);
+
+        for (size_t i = 0; i < p - n; ++i)
+        {
+            r[i * p + i] = one;
+            PRAGMA_IVDEP
+            PRAGMA_VECTOR_ALWAYS
+            for (size_t j = 0; j < i; ++j)
+            {
+                r[i * p + j] = zero;
+            }
+        }
+
+        for (size_t i = 0; i < (p - n) * ny; ++i)
+        {
+            qty[i] = zero;
+        }
+    }
+
     /* Copy result into matrix QTY */
-    const DAAL_INT qtySize = ny * p * sizeof(algorithmFPType);
-    const DAAL_INT yqtOffset = (n - p) * ny;
-    int result = daal::services::internal::daal_memcpy_s(qty, qtySize, y + yqtOffset, qtySize);
+    const DAAL_INT qtySize   = ny * (n > p ? p : n) * sizeof(algorithmFPType);
+    const DAAL_INT yOffset   = (n > p ? (n - p) * ny : 0);
+    const DAAL_INT qtyOffset = (n > p ? 0 : (p - n) * ny);
+
+    int result = daal::services::internal::daal_memcpy_s(qty + qtyOffset, qtySize, y + yOffset, qtySize);
 
     return (!result) ? Status() : Status(services::ErrorMemoryCopyFailedInternal);
 }
 
 template <typename algorithmFPType, CpuType cpu>
-Status CommonKernel<algorithmFPType, cpu>::merge(DAAL_INT nBetas, DAAL_INT nResponses,
-                                                const algorithmFPType *r1, const algorithmFPType * qty1,
-                                                const algorithmFPType *r2, const algorithmFPType * qty2,
-                                                algorithmFPType *r12, algorithmFPType * qty12,
-                                                algorithmFPType *r, algorithmFPType * qty,
-                                                algorithmFPType *tau, algorithmFPType *work, DAAL_INT lwork)
+Status CommonKernel<algorithmFPType, cpu>::merge(DAAL_INT nBetas, DAAL_INT nResponses, const algorithmFPType * r1, const algorithmFPType * qty1,
+                                                 const algorithmFPType * r2, const algorithmFPType * qty2, algorithmFPType * r12,
+                                                 algorithmFPType * qty12, algorithmFPType * r, algorithmFPType * qty, algorithmFPType * tau,
+                                                 algorithmFPType * work, DAAL_INT lwork)
 {
     /* Copy R1 and R2 into R12. R12 = (R1, R2) */
     int result = 0;
     Status status;
 
-    size_t rSize = nBetas * nBetas;
+    size_t rSize        = nBetas * nBetas;
     size_t rSizeInBytes = rSize * sizeof(algorithmFPType);
-    result |= daal::services::internal::daal_memcpy_s(r12        , 2 * rSizeInBytes, r1, rSizeInBytes);
-    result |= daal::services::internal::daal_memcpy_s(r12 + rSize,     rSizeInBytes, r2, rSizeInBytes);
+    result |= daal::services::internal::daal_memcpy_s(r12, 2 * rSizeInBytes, r1, rSizeInBytes);
+    result |= daal::services::internal::daal_memcpy_s(r12 + rSize, rSizeInBytes, r2, rSizeInBytes);
     /* Copy QTY1 and QTY2 into QTY12. QTY12 = (QTY1, QTY2) */
-    size_t qtySize = nBetas * nResponses;
-    size_t qtySizeInBytes  = qtySize * sizeof(algorithmFPType);
-    result |= daal::services::internal::daal_memcpy_s(qty12          , 2 * qtySizeInBytes, qty1, qtySizeInBytes);
-    result |= daal::services::internal::daal_memcpy_s(qty12 + qtySize,     qtySizeInBytes, qty2, qtySizeInBytes);
+    size_t qtySize        = nBetas * nResponses;
+    size_t qtySizeInBytes = qtySize * sizeof(algorithmFPType);
+    result |= daal::services::internal::daal_memcpy_s(qty12, 2 * qtySizeInBytes, qty1, qtySizeInBytes);
+    result |= daal::services::internal::daal_memcpy_s(qty12 + qtySize, qtySizeInBytes, qty2, qtySizeInBytes);
 
     DAAL_INT n = 2 * nBetas;
-    status = CommonKernel<algorithmFPType, cpu>::computeQRForBlock(nBetas, n, r12, nResponses, qty12, r, qty, tau, work, lwork);
+    status     = CommonKernel<algorithmFPType, cpu>::computeQRForBlock(nBetas, n, r12, nResponses, qty12, r, qty, tau, work, lwork);
 
     return (!result) ? status : Status(services::ErrorMemoryCopyFailedInternal);
 }
 
-}
-}
-}
-}
-}
-}
+} // namespace internal
+} // namespace training
+} // namespace qr
+} // namespace linear_model
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/linear_regression/linear_regression_training_input.cpp
+++ b/algorithms/kernel/linear_regression/linear_regression_training_input.cpp
@@ -36,10 +36,9 @@ namespace training
 {
 namespace interface1
 {
-
 /** Default constructor */
 Input::Input() : linear_model::training::Input(lastInputId + 1) {}
-Input::Input(const Input& other) : linear_model::training::Input(other){}
+Input::Input(const Input & other) : linear_model::training::Input(other) {}
 
 /**
  * Returns an input object for linear regression model-based training
@@ -56,7 +55,7 @@ NumericTablePtr Input::get(InputId id) const
  * \param[in] id      Identifier of the input object
  * \param[in] value   Pointer to the object
  */
-void Input::set(InputId id, const NumericTablePtr &value)
+void Input::set(InputId id, const NumericTablePtr & value)
 {
     linear_model::training::Input::set(linear_model::training::InputId(id), value);
 }
@@ -65,25 +64,38 @@ void Input::set(InputId id, const NumericTablePtr &value)
  * Returns the number of columns in the input data set
  * \return Number of columns in the input data set
  */
-size_t Input::getNumberOfFeatures() const { return get(data)->getNumberOfColumns(); }
+size_t Input::getNumberOfFeatures() const
+{
+    return get(data)->getNumberOfColumns();
+}
 
 /**
  * Returns the number of dependent variables
  * \return Number of dependent variables
  */
-size_t Input::getNumberOfDependentVariables() const { return get(dependentVariables)->getNumberOfColumns(); }
+size_t Input::getNumberOfDependentVariables() const
+{
+    return get(dependentVariables)->getNumberOfColumns();
+}
 
-services::Status Input::check(const daal::algorithms::Parameter *par, int method) const
+services::Status Input::check(const daal::algorithms::Parameter * par, int method) const
 {
     Status s;
     DAAL_CHECK_STATUS(s, linear_model::training::Input::check(par, method));
 
-    const Parameter *parameter = static_cast<const Parameter *>(par);
+    const Parameter * parameter = static_cast<const Parameter *>(par);
 
     NumericTablePtr dataTable = get(data);
-    size_t nRowsInData = dataTable->getNumberOfRows();
-    size_t nColumnsInData = dataTable->getNumberOfColumns();
-    DAAL_CHECK(nRowsInData >= nColumnsInData + (int)(method == qrDense && parameter->interceptFlag == true), ErrorIncorrectNumberOfRows);
+    size_t nRowsInData        = dataTable->getNumberOfRows();
+    size_t nColumnsInData     = dataTable->getNumberOfColumns();
+    if (method == normEqDense)
+    {
+        DAAL_CHECK(nRowsInData >= nColumnsInData + (int)(parameter->interceptFlag == true), ErrorIncorrectNumberOfRows);
+    }
+    else
+    {
+        DAAL_CHECK(nRowsInData > 0, ErrorIncorrectNumberOfRows);
+    }
     return s;
 }
 


### PR DESCRIPTION
Same as, but to rls/daal-2020-mnt: https://github.com/intel/daal/pull/455

The changes aim to pass arguments properly to LAPACK XORMRQ function in case n_observations < n_betas.
The results of XORMRQ are appended: R - with unit diagonal sub-matrix; QtY - with zero rows; to make the resulting linear system solvable.

CI (successful):  http://intel-ci.intel.com/ea6ceb77-3e57-f18f-9a61-8cdcd4b723a1