### PR TITLE
[releases] Add ability to train linear and ridge regression with n_observations < n_beta in QR method

### DIFF
--- a/algorithms/kernel/linear_model/linear_model_train_qr_update_impl.i
+++ b/algorithms/kernel/linear_model/linear_model_train_qr_update_impl.i
@@ -54,7 +54,7 @@ ThreadingTask<algorithmFPType, cpu>::ThreadingTask(DAAL_INT nBetasIntercept, DAA
       _yBlock(),
       tau(nBetasIntercept),
       qrBuffer(nBetasIntercept * nRows),
-      qtyBuffer(nResponses * nRows),
+      qtyBuffer(nResponses * (nRows > nBetasIntercept ? nRows : nBetasIntercept)),
       qrR(nBetasIntercept * nBetasIntercept),
       qrQTY(nBetasIntercept * nResponses),
       qrRNew(nBetasIntercept * nBetasIntercept),
@@ -205,7 +205,8 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
 
     size_t nBlocks  = nRows / nRowsInBlock;
     size_t tailSize = nRows - nBlocks * nRowsInBlock;
-    if (tailSize > nBetasIntercept) nBlocks++;
+    if (tailSize > nBetasIntercept) ++nBlocks;
+    if (!nBlocks) ++nBlocks;
 
     /* Create TLS */
     daal::tls<ThreadingTaskType *> tls([=]() -> ThreadingTaskType * { return ThreadingTaskType::create(nBetasIntercept, nRowsInBlock, nResponses); });

--- a/algorithms/kernel/linear_regression/linear_regression_training_input.cpp
+++ b/algorithms/kernel/linear_regression/linear_regression_training_input.cpp
@@ -88,7 +88,14 @@ services::Status Input::check(const daal::algorithms::Parameter * par, int metho
     NumericTablePtr dataTable = get(data);
     size_t nRowsInData        = dataTable->getNumberOfRows();
     size_t nColumnsInData     = dataTable->getNumberOfColumns();
-    DAAL_CHECK(nRowsInData >= nColumnsInData + (int)(method == qrDense && parameter->interceptFlag == true), ErrorIncorrectNumberOfRows);
+    if (method == normEqDense)
+    {
+        DAAL_CHECK(nRowsInData >= nColumnsInData + (int)(parameter->interceptFlag == true), ErrorIncorrectNumberOfRows);
+    }
+    else
+    {
+        DAAL_CHECK(nRowsInData > 0, ErrorIncorrectNumberOfRows);
+    }
     return s;
 }
 


### PR DESCRIPTION
Same as, but to releases: #455

The changes aim to pass arguments properly to LAPACK XORMRQ function in case n_observations < n_betas.
The results of XORMRQ are appended: R - with unit diagonal sub-matrix; QtY - with zero rows; to make the resulting linear system solvable.

CI (successful): http://intel-ci.intel.com/ea6cecf3-a379-f1a9-8625-8cdcd4b723a1